### PR TITLE
Adds a 'catch-all' php route

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -11,7 +11,18 @@ return [
 	'routes' => [
 		[
 			'name' => 'page#index',
-			'url' => '/', 'verb' => 'GET'
+			'url' => '/',
+			'verb' => 'GET',
+		],
+		// The following route is there to prevent redirection to NC's general homepage
+		// when reloading a page in the application (If we don't add it all pages that
+		// don't have a route registered here redirect to NC's general homepage upon refresh)
+		[
+			'name' => 'page#index',
+			'url' => '/{path}',
+			'verb' => 'GET',
+			'requirements' => array('path' => '.+'),
+			'defaults' => array('path' => 'dummy'),
 		],
 		[
 			'name' => 'page#autoComplete',


### PR DESCRIPTION
Adds a 'catch-all' php route to prevent being redirected to NC's general homepage when reloading pages

Signed-off-by: Cyrille Bollu <cyr.debian@bollu.be>