### PR TITLE
Add 'build/' folder to ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 vendor/
 js/*
+build/


### PR DESCRIPTION
When I run `make appstore` command. Git tell me of the `build/` folder is untracked.