### PR TITLE
Fixes the layout of the group navigation entries that were not using the whole width of the left navigation panel

### DIFF
--- a/src/Home.vue
+++ b/src/Home.vue
@@ -24,7 +24,7 @@
 				:title="name"
 				:to="{path: `/workspace/${name}`}">
 				<AppNavigationIconBullet slot="icon" :color="space.color" />
-				<CounterBubble slot="counter">
+				<CounterBubble slot="counter" class="user-counter">
 					{{ $store.getters.spaceUserCount(name) }}
 				</CounterBubble>
 				<div>
@@ -33,7 +33,7 @@
 						icon="icon-group"
 						:to="{path: `/group/${name}/${group[0]}`}"
 						:title="group[0]">
-						<CounterBubble slot="counter">
+						<CounterBubble slot="counter" class="user-counter">
 							{{ $store.getters.groupUserCount( name, group[0]) }}
 						</CounterBubble>
 					</AppNavigationItem>
@@ -143,15 +143,15 @@ export default {
 	display: block;
 }
 
-.app-navigation-entry {
-	padding-right: 5px;
-}
-
 .space-selected {
 	background-color: #EAF5FC;
 }
 
 tr:hover {
 	background-color: #f5f5f5;
+}
+
+.user-counter {
+	margin-right: 5px;
 }
 </style>


### PR DESCRIPTION
Fixes this:

![image](https://user-images.githubusercontent.com/8179031/122372258-d27ab800-cf60-11eb-8141-441bb09af302.png)

result with the PR (no grey vertical line anymore):

![image](https://user-images.githubusercontent.com/8179031/122372417-f1794a00-cf60-11eb-8313-20e7e3bc0915.png)

Signed-off-by: Cyrille Bollu <cyr.debian@bollu.be>