### PR TITLE
Print groupname in the space and group detail

### DIFF
--- a/lib/Service/UserService.php
+++ b/lib/Service/UserService.php
@@ -45,8 +45,8 @@ Class UserService {
 		$groups = [];
 		foreach($this->groupManager->getUserGroups($user) as $group) {
 			if (substr_compare($group->getGID(), $space['id'], -strlen($space['id'])) === 0
-				|| $group->getGID() === Application::ESPACE_MANAGER_01 . $space['mount_point']
-				|| $group->getGID() === Application::ESPACE_USERS_01 . $space['mount_point']
+				|| $group->getGID() === Application::ESPACE_MANAGER_01 . $space['space_name']
+				|| $group->getGID() === Application::ESPACE_USERS_01 . $space['space_name']
 			) {
 				array_push($groups, $group->getGID());
 			}


### PR DESCRIPTION
Resolve the printing groupname in the space detail and group detail.

![resolve-group-20210713](https://user-images.githubusercontent.com/28636549/125450870-b8d457d9-8102-491e-9134-1d86b786d9ce.gif)

This PR resolve the #146 issue.