### PR TITLE
Lowers z-index of user badges in SelectUsers

### DIFF
--- a/src/SelectUsers.vue
+++ b/src/SelectUsers.vue
@@ -225,7 +225,7 @@ export default {
 	position: relative;
 	left: 10px;
 	top: -10px;
-	z-index: 100;
+	z-index: 10;
 	width: 20px;
 	height: 20px;
 }


### PR DESCRIPTION
the z-index of the badge of user who are already member of the workspace is too high: It shows up above the user selection list

![image](https://user-images.githubusercontent.com/8179031/126795396-e43954c9-bac1-49a8-a223-b0f29fe96cf1.png)

This PR fixes this issue

Signed-off-by: Cyrille Bollu <cyr.debian@bollu.be>