### PR TITLE
Fixes 2 issues in group user counts in the frontend

### DIFF
--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -26,6 +26,12 @@ export default {
 			user: user.uid,
 		}).then((resp) => {
 			if (resp.status === 204) {
+				// Everything went well, we can thus also add this user to the UGroup in the frontend
+				context.commit('addUserToGroup', {
+					name,
+					gid: context.getters.UGroup(name).gid,
+					user,
+				})
 				// eslint-disable-next-line no-console
 				console.log('User ' + user.name + ' added to group ' + gid)
 			} else {

--- a/src/store/mutations.js
+++ b/src/store/mutations.js
@@ -43,12 +43,14 @@ export default {
 		sortSpaces(state)
 	},
 	// Adds a user to a group
-	// We must add the group to the user's groups property and
-	// add the the user to the space's users property
 	addUserToGroup(state, { name, gid, user }) {
-		user.groups.push(gid)
 		const space = state.spaces[name]
-		space.users[user.name] = user
+		if (space.users[user.name] !== undefined) {
+			space.users[user.name].groups.push(gid)
+		} else {
+			user.groups.push(gid)
+			space.users[user.name] = user
+		}
 		Vue.set(state.spaces, name, space)
 		sortSpaces(state)
 	},


### PR DESCRIPTION
Fixes 2 issues in group user counts in the frontend:

1. Fixes a bug in the frontend when a user would lose its groups' memembership when it is added to a subgroup
2. Fixes user is not directly added to U- group in frontend when add it to a subgroup

Signed-off-by: Cyrille Bollu <cyr.debian@bollu.be>