### PR TITLE
Fixes WorkspaceController::findAll calls isUserManagerOfSpace with space name  instead of space id

### DIFF
--- a/lib/Controller/WorkspaceController.php
+++ b/lib/Controller/WorkspaceController.php
@@ -353,7 +353,7 @@ class WorkspaceController extends Controller {
         if (!$this->userService->isUserGeneralAdmin()) {
             $this->logger->debug('Filtering workspaces');
             $filteredSpaces = array_filter($spaces, function($space) {
-                return $this->userService->isSpaceManagerOfSpace($space['space_name']);
+                return $this->userService->isSpaceManagerOfSpace($space['id']);
             });
             
             $spaces = $filteredSpaces;


### PR DESCRIPTION
Fixes #215 

Signed-off-by: Cyrille Bollu <cyr.debian@bollu.be>