### PR TITLE
Searching all users who are enabled only

### DIFF
--- a/lib/Service/UserService.php
+++ b/lib/Service/UserService.php
@@ -52,7 +52,14 @@ Class UserService {
 	public function autoComplete(string $term, string $spaceId) {
 		// lookup users
 		$term = $term === '*' ? '' : $term;
-		$users = $this->userManager->searchDisplayName($term, 50);
+		$searchingUsers = $this->userManager->searchDisplayName($term, 50);
+		
+		$users = [];
+		foreach($searchingUsers as $user) {
+			if($user->isEnabled()) {
+					$users[] = $user;
+				}
+		}
 
 		// transform in a format suitable for the app
 		$data = [];


### PR DESCRIPTION
We must search all users who are enabled only.


![select-users-enabled](https://user-images.githubusercontent.com/28636549/129031642-39f5742d-b6c5-4098-9ebd-b02133c13710.gif)


@StCyr : Can you test this PR, please ?