### PR TITLE
Hides the rename and delete group buttons for GE- and U- groups

### DIFF
--- a/src/GroupDetails.vue
+++ b/src/GroupDetails.vue
@@ -27,18 +27,20 @@
 					</Actions>
 				</div>
 				<Actions>
-					<ActionButton v-show="!showRenameGroupInput"
+					<ActionButton v-if="!$store.getters.isGEorUGroup($route.params.space, $route.params.group)"
+						v-show="!showRenameGroupInput"
 						icon="icon-rename"
 						@click="toggleShowRenameGroupInput">
 						{{ t('workspace', 'Rename group') }}
 					</ActionButton>
-					<ActionInput v-show="showRenameGroupInput"
+					<ActionInput v-if="!$store.getters.isGEorUGroup($route.params.space, $route.params.group)"
+						v-show="showRenameGroupInput"
 						ref="renameGroupInput"
 						icon="icon-group"
 						@submit="onRenameGroup">
 						{{ t('workspace', 'Group name') }}
 					</ActionInput>
-					<ActionButton
+					<ActionButton v-if="!$store.getters.isGEorUGroup($route.params.space, $route.params.group)"
 						icon="icon-delete"
 						@click="deleteGroup">
 						{{ t('workspace', 'Delete group') }}

--- a/src/SelectUsers.vue
+++ b/src/SelectUsers.vue
@@ -46,7 +46,7 @@
 						</div>
 					</div>
 					<div class="user-entry-actions">
-						<div v-if="!isGEorUGroup">
+						<div v-if="!$store.getters.isGEorUGroup($route.params.space, $route.params.group)">
 							<input type="checkbox" class="role-toggle" @change="toggleUserRole(user)">
 							<label>{{ t('workspace', 'S.A.') }}</label>
 						</div>
@@ -103,14 +103,6 @@ export default {
 			return !this.allSelectedUsers.every(user => {
 				return this.$store.getters.isMember(this.$route.params.space, user)
 			})
-		},
-		// Returns true if we are adding users to the GE or User group of this workspace
-		isGEorUGroup() {
-			if (this.$route.params.group === this.$store.getters.GEGroup(this.$route.params.space).gid
-			|| this.$route.params.group === this.$store.getters.UGroup(this.$route.params.space).gid) {
-				return true
-			}
-			return false
 		},
 	},
 	created() {

--- a/src/store/getters.js
+++ b/src/store/getters.js
@@ -2,6 +2,8 @@ import { ESPACE_MANAGERS_PREFIX, ESPACE_USERS_PREFIX } from '../constants'
 
 export const getters = {
 	// Returns the GE group of a workspace
+	// POSSIBLE IMPROVEMENT: This would better be done with GID rather than displayName but
+	// displayName is not supposed to change neither
 	GEGroup: state => name => {
 		const groups = Object.values(state.spaces[name].groups).filter(group => {
 			return group.displayName === ESPACE_MANAGERS_PREFIX + name
@@ -21,6 +23,14 @@ export const getters = {
 			// Counts all users in the space who have 'gid' listed in their 'groups' property
 			return Object.values(users).filter(user => user.groups.includes(gid)).length
 		}
+	},
+	// Tests wheter a group is the GE or U group of a space
+	isGEorUGroup: (state, getters) => (spaceName, gid) => {
+		if (gid === getters.GEGroup(spaceName).gid
+		|| gid === getters.UGroup(spaceName).gid) {
+			return true
+		}
+		return false
 	},
 	// Tests whether a user is member of workspace
 	isMember: state => (name, user) => {
@@ -45,6 +55,8 @@ export const getters = {
 		}
 	},
 	// Returns the U- group of a workspace
+	// POSSIBLE IMPROVEMENT: This would better be done with GID rather than displayName but
+	// displayName is not supposed to change neither
 	UGroup: state => name => {
 		const groups = Object.values(state.spaces[name].groups).filter(group => {
 			return group.displayName === ESPACE_USERS_PREFIX + name


### PR DESCRIPTION
when viewing a subgroup:

![image](https://user-images.githubusercontent.com/8179031/129756178-d674ae71-b7a4-4b5c-b8e0-3acec85ca63a.png)

when viewing a GE or U group:

![image](https://user-images.githubusercontent.com/8179031/129756227-3ca446e5-3984-4821-a461-a135bb25bd8e.png)

Signed-off-by: Cyrille Bollu <cyr.debian@bollu.be>