### PR TITLE
fix(Vue): Add the groupfolderId when a space is created

### DIFF
--- a/src/Home.vue
+++ b/src/Home.vue
@@ -154,6 +154,7 @@ export default {
 							groups: resp.data.groups,
 							isOpen: false,
 							id: resp.data.id_space,
+							groupfolderId: resp.data.folder_id,
 							name,
 							quota: undefined,
 							users: [],


### PR DESCRIPTION
After creating a space. It's not impossible to set a quota. Because, the  key wasn't define. So, I added this key `groupfolderId: resp.data.folder_id` when we create a space.

Revolved this issue : https://github.com/arawa/workspace/issues/265