### PR TITLE
fix(Vue): Change the css for the Multiselect component

### DIFF
--- a/src/SpaceDetails.vue
+++ b/src/SpaceDetails.vue
@@ -17,7 +17,7 @@
 					{{ title }}
 				</span>
 				<Multiselect
-					class="quota-select"
+					:class="isESR ? 'quota-select-esr' : 'quota-select'"
 					:disabled="$root.$data.isUserGeneralAdmin === 'false'"
 					:placeholder="t('workspace', 'Set quota')"
 					:taggable="true"
@@ -104,6 +104,13 @@ export default {
 			createGroup: false, // true to display 'Create Group' ActionInput
 			renameSpace: false, // true to display 'Rename space' ActionInput
 			showSelectUsersModal: false, // true to display user selection Modal windows
+			isESR: false,
+		}
+	},
+	created() {
+		const version = navigator.userAgent.split('Firefox/')[1]
+		if (parseInt(version) < 91) {
+			this.isESR = true
 		}
 	},
 	computed: {
@@ -253,6 +260,12 @@ export default {
 	margin-left: 20px !important;
 	min-width: 100px;
 	max-width: 100px;
+}
+
+.quota-select-esr {
+	margin-left: 20px !important;
+	min-width: 100px;
+	max-width: 100% !important;
 }
 
 .space-color-picker {


### PR DESCRIPTION
If the Fiefox Browser is a ESR release, the Multiselect component will be the `100% !important` as value for the `width` in css.

![image](https://user-images.githubusercontent.com/28636549/131150923-039ea28b-cc81-4b95-bea7-23fd5d5282b6.png)

Can resolve this issue : https://github.com/arawa/workspace/issues/297

@StCyr : Can you check this PR if it's okay for you, please ?