### PR TITLE
Get rid of method WorkspaceController::removeUserFromWorkspace.

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -52,11 +52,6 @@ return [
 			'verb' => 'PATCH'
 	    	],
 		[
-			'name' => 'workspace#removeUserFromWorkspace',
-			'url' => '/api/space/{spaceId}/user/{userId}',
-			'verb' => 'DELETE'
-		],
-		[
 			'name' => 'workspace#changeUserRole',
 			'url' => '/api/space/{spaceId}/user/{userId}',
 			'verb' => 'PATCH'

--- a/lib/Controller/WorkspaceController.php
+++ b/lib/Controller/WorkspaceController.php
@@ -388,42 +388,4 @@ class WorkspaceController extends Controller {
         }
     }
 
-	/**
-	*
-	* Removes a user from a workspace
-	*
-	* @NoAdminRequired
-	* @SpaceAdminRequired
-	*
-	* @var string $spaceId
-	* @var string $userId
-	* 
-	*/
-	public function removeUserFromWorkspace(string $spaceId, string $userId) {
-		$this->logger->debug('Removing user ' . $userId . ' from workspace ' . $spaceId);
-
-		$user = $this->userManager->get($userId);
-		$space = $this->workspaceService->get($spaceId);
-		$GEgroup = $this->groupManager->get(Application::GID_SPACE . Application::ESPACE_MANAGER_01 . $spaceId);
-
-		// If user is a general manager we may first have to remove it from the list of users allowed to use
-		// the application
-		if ($GEgroup->inGroup($user)) {
-			$this->logger->debug('User is manager of the workspace, removing it from the WorkspacesManagers group if needed.');
-			$this->userService->removeGEFromWM($user, $space);
-		}
-
-		// We can now blindly remove the user from the space's admin and user groups
-		$this->logger->debug('Removing user from workspace.');
-		$GEgroup->removeUser($user);
-		$UserGroup = $this->groupManager->get(Application::GID_SPACE . Application::ESPACE_USERS_01 . $spaceId);
-		$UserGroup->removeUser($user);
-
-		// Removes user from all 'subgroups' when we remove it from the workspace's user group
-		foreach(array_keys($space['groups']) as $gid) {
-			$NCGroup = $this->groupManager->get($gid)->removeUser($user);
-		}
-
-		return new JSONResponse();
-	}
 }

--- a/src/SpaceDetails.vue
+++ b/src/SpaceDetails.vue
@@ -107,17 +107,17 @@ export default {
 			isESR: false,
 		}
 	},
-	created() {
-		const version = navigator.userAgent.split('Firefox/')[1]
-		if (parseInt(version) < 91) {
-			this.isESR = true
-		}
-	},
 	computed: {
 		// The title to display at the top of the page
 		title() {
 			return this.$route.params.space + ' [ID: ' + this.$store.state.spaces[this.$route.params.space].id + ']'
 		},
+	},
+	created() {
+		const version = navigator.userAgent.split('Firefox/')[1]
+		if (parseInt(version) < 91) {
+			this.isESR = true
+		}
 	},
 	methods: {
 		// Deletes a space

--- a/src/UserTable.vue
+++ b/src/UserTable.vue
@@ -82,6 +82,7 @@ import Actions from '@nextcloud/vue/dist/Components/Actions'
 import ActionButton from '@nextcloud/vue/dist/Components/ActionButton'
 import Avatar from '@nextcloud/vue/dist/Components/Avatar'
 import EmptyContent from '@nextcloud/vue/dist/Components/EmptyContent'
+import { ESPACE_USERS_PREFIX, ESPACE_GID_PREFIX } from './constants'
 
 export default {
 	name: 'UserTable',
@@ -130,10 +131,12 @@ export default {
 		},
 	},
 	methods: {
-		// Removes a user's access to a workspace
+		// Removes a user from a workspace
 		deleteUser(user) {
-			this.$store.dispatch('removeUserFromSpace', {
+			const space = this.$store.state.spaces[this.$route.params.space]
+			this.$store.dispatch('removeUserFromGroup', {
 				name: this.$route.params.space,
+				gid: ESPACE_GID_PREFIX + ESPACE_USERS_PREFIX + space.id,
 				user,
 			})
 		},

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -177,36 +177,6 @@ export default {
 			}
 		})
 	},
-	// Removes a user from a space
-	removeUserFromSpace(context, { name, user }) {
-		const space = context.state.spaces[name]
-		context.commit('removeUserFromWorkspace', { name, user })
-		axios.delete(generateUrl('/apps/workspace/api/space/{spaceId}/user/{userId}', {
-			spaceId: space.id,
-			userId: user.uid,
-		}))
-			.then((resp) => {
-				if (resp.status !== 200) {
-					// Revert action an inform user
-					context.commit('addUserToWorkspace', user)
-					this._vm.$notify({
-						title: t('workspace', 'Error'),
-						text: t('workspace', 'An error occured while trying to add user ') + user.name + t('workspace', ' to workspace.<br>The error is: ') + resp.statusText,
-						type: 'error',
-					})
-				}
-			}).catch((e) => {
-				// Revert action an inform user
-				context.commit('addUserToWorkspace', user)
-				this._vm.$notify({
-					title: t('workspace', 'Network error'),
-					text: t('workspace', 'A networks error occured while trying to add user ') + user.name + t('workspace', ' to workspace.<br>The error is: ') + e,
-					type: 'error',
-				})
-			})
-		// eslint-disable-next-line no-console
-		console.log('User ' + user.name + ' removed from space ' + name)
-	},
 	// Renames a group and navigates to its details page
 	renameGroup(context, { name, gid, newGroupName }) {
 		const space = context.state.spaces[name]


### PR DESCRIPTION
The same functionality is achieved by GroupController::removeUser when the group from which we want to remove a user is a U- group.

Fixes #278 

Signed-off-by: Cyrille Bollu <cyr.debian@bollu.be>