### PR TITLE
fix: Move the group title

### DIFF
--- a/src/GroupDetails.vue
+++ b/src/GroupDetails.vue
@@ -155,7 +155,8 @@ export default {
 }
 
 .group-name {
-	margin-left: 40px;
+	margin-left: 8px;
+	margin-top: -40px;
 }
 
 </style>


### PR DESCRIPTION
For more harmonious with the group title. I changed the values CSS and the group title has the same position than space title.

![group-title-move](https://user-images.githubusercontent.com/28636549/132667367-8af1094c-6970-40fb-a915-f6b384f5005f.gif)

Resolve this issue : https://github.com/arawa/workspace/issues/264