### PR TITLE
fix(Vue,l10n): Warning message to set quota

### DIFF
--- a/l10n/en.js
+++ b/l10n/en.js
@@ -36,8 +36,6 @@ OC.L10N.register(
 		'remove users from selection': 'remove users from selection',
 		'Error - Creating space': 'Error - Creating space',
 		'You may only specify "unlimited" or a number followed by "TB", "GB", "MB", or "KB" (eg: "5GB") as quota': 'Vous devez spécifier le terme "unlimited" ou un nombre suivi de "TB", "GB", "MB" ou "KB" (exemple: "5GB") comme quota.',
-		'Warning - Set quota': 'Warning - Set quota',
-		'This workspace quota is already.': 'This workspace quota is already.',
 		'This space or groupfolder already exist. Please, input another space.\nIf "toto" space exist, you cannot create the "tOTo" space.\nMake sure you the groupfolder doesn\'t exist.': 'This space or groupfolder already exist. Please, input another space.\nIf "toto" space exist, you cannot create the "tOTo" space.\nMake sure you the groupfolder doesn\'t exist.',
 	},
 "nplurals=2; plural=(n > 1)");

--- a/l10n/fr.js
+++ b/l10n/fr.js
@@ -36,8 +36,6 @@ OC.L10N.register(
 		'Workspace name': "Nom de l'espace de travail",
 		'Error - Creating space': 'Erreur - Création d\'un espace de travail',
 		'You may only specify "unlimited" or a number followed by "TB", "GB", "MB", or "KB" (eg: "5GB") as quota': 'Vous devez spécifier le terme "unlimited" ou un nombre suivi de "TB", "GB", "MB" ou "KB" (exemple: "5GB") comme quota.',
-		'Warning - Set quota': 'Attention - Définition du quota',
-		'This workspace quota is already.': 'Cet espace possède déjà ce quota.',
 		'This space or groupfolder already exist. Please, input another space.\nIf "toto" space exist, you cannot create the "tOTo" space.\nMake sure you the groupfolder doesn\'t exist.': 'Cet espace projet ou le dossier du groupe (groupfolder) existe déjà. Saisissez un autre espace, s\'il vous plaît.\nPar exemple, si l\'espace "toto" existe, vous ne pouvez pas créer l\'espace "tOTo".\nAssurez-vous que le groupfolder n\'existe pas.'
 	},
 "nplurals=2; plural=(n > 1)");

--- a/l10n/fr.json
+++ b/l10n/fr.json
@@ -28,8 +28,6 @@
 	"Remove from group": "Retirer du groupe",
 	"No users": "Pas d'utilisateur",
 	"You may only specify \"unlimited\" or a number followed by \"TB\", \"GB\", \"MB\", or \"KB\" (eg: \"5GB\") as quota": "Vous devez spécifier le terme \"unlimited\" ou un nombre suivi de \"TB\", \"GB\", \"MB\" ou \"KB\" (exemple: \"5GB\") comme quota.",
-	"This workspace quota is already." : "Cet espace possède déjà ce quota.",
-	"Warning - Set quota": "Attention - Définition du quota",
 	"There are no users in this space/group yet": "Il n'y a pas encore d'utilisateur dans cet espace de travail",
 	"Start typing to lookup users": "Commencez à saisir du texte pour rechercher des utilisateurs",
 	"remove users from selection": "retirer l'utilisateur de la sélection"

--- a/src/SpaceDetails.vue
+++ b/src/SpaceDetails.vue
@@ -192,11 +192,6 @@ export default {
 		// Sets a space's quota
 		setSpaceQuota(quota) {
 			if (quota === null) {
-				this.$notify({
-					title: t('workspace', 'Warning - Set quota'),
-					text: t('workspace', 'This workspace quota is already.'),
-					type: 'warning',
-				})
 				return
 			}
 			const control = /^(unlimited|\d+(tb|gb|mb|kb)?)$/i


### PR DESCRIPTION
When the user selects the same quota, a warning message let him know that the quota is already define

![warning-define-quota](https://user-images.githubusercontent.com/28636549/132818558-43097b04-5938-413b-8962-6fa15dc70362.gif)

Resolve this issue: https://github.com/arawa/workspace/issues/294