### PR TITLE
2 improvements to try to improve user's experience with the SelectUsers dialog

### DIFF
--- a/src/SelectUsers.vue
+++ b/src/SelectUsers.vue
@@ -25,6 +25,7 @@
 			:tag-width="50"
 			:user-select="true"
 			@change="addUsersToBatch"
+			@close="selectableUsers=[]"
 			@search-change="lookupUsers" />
 		<div class="select-users-list">
 			<div v-if="allSelectedUsers.length === 0"


### PR DESCRIPTION
2 improvements to try to improve user's experience with the SelectUsers dialog:

1. Do not prefetch users when the dialog opens
2. Clear list of selectable users when user closes the dropdown list