### PR TITLE
fix(Vue): The space-name container is moved

### DIFF
--- a/src/SpaceDetails.vue
+++ b/src/SpaceDetails.vue
@@ -277,7 +277,7 @@ export default {
 
 .space-name {
 	margin-left: 8px;
-	margin-top: -40px;
+	margin-top: -25px;
 }
 
 .user-actions {


### PR DESCRIPTION
I add a margin-top: -25px

![image](https://user-images.githubusercontent.com/28636549/133797834-94da24b2-1577-4a07-9ade-ed107aedf372.png)


Resolve this issue : https://github.com/arawa/workspace/issues/325