### PR TITLE
fix(): Add a hover on the spaces table

### DIFF
--- a/css/workspace-style.css
+++ b/css/workspace-style.css
@@ -11,6 +11,11 @@ tr {
 	height: 50px;
 	padding: 5px;
 }
+
+tr:hover {
+	background-color: #f5f5f5;
+}
+
 .list-users:hover {
 	background-color: #f5f5f5;
 }

--- a/src/Home.vue
+++ b/src/Home.vue
@@ -254,10 +254,6 @@ export default {
 	background-color: inherit !important;
 }
 
-tr:hover {
-	background-color: #f5f5f5;
-}
-
 .user-counter {
 	margin-right: 5px;
 }

--- a/src/SpaceTable.vue
+++ b/src/SpaceTable.vue
@@ -109,9 +109,4 @@ export default {
 	justify-content: space-between;
 }
 
-tr:hover {
-	background-color: #f5f5f5;
-	cursor: pointer;
-}
-
 </style>


### PR DESCRIPTION
When you are in the spaces table, you can move your mouse and the background-color change with the hover

![hover-space-home](https://user-images.githubusercontent.com/28636549/133801547-3b7d336b-e6e6-402c-b486-be9a8f125daf.gif)

Resolve this issue: https://github.com/arawa/workspace/issues/326

@StCyr : I add the `cursor: pointer` in the component's css file. But, it doesn't work... Can you test this feature ?