### PR TITLE
Improvements in the sorting of workspaces in the left panel

### DIFF
--- a/src/store/mutations.js
+++ b/src/store/mutations.js
@@ -13,8 +13,8 @@ const sortSpaces = (state) => {
 			// This is especially the case of the mocha test framework
 			try {
 				return a.localeCompare(b, getLocale(), {
+					numeric: true,
 					sensitivity: 'base',
-					ignorePunctuation: true,
 				})
 			} catch (e) {
 				return a.localeCompare(b)


### PR DESCRIPTION
Workspaces are now sorted as follow:

1. first, workspaces starting with special characters
2. then, workspaces starting with numbers, sorted numericaly (ie: '5 test' comes before '10 test')
3. finaly, workspaces starting with alphabetical characters, sorted alphabeticaly taking locale
 into account (eg.: 'ex' comes after 'été' which come after 'erreur')

Signed-off-by: Cyrille Bollu <cyr.debian@bollu.be>