### PR TITLE
Redesign(Vue): Redesign of the selecting users

### DIFF
--- a/src/SelectUsers.vue
+++ b/src/SelectUsers.vue
@@ -274,7 +274,7 @@ export default {
 
 .select-users-input {
 	align-self: start;
-	width: 70%;
+	width: 80%;
 	margin-left: auto !important;
 	margin-right: auto !important;
 }
@@ -285,7 +285,7 @@ export default {
 	border-style: solid;
 	border-width: 1px;
 	border-color: transparent;
-	width: 72%;
+	width: 82%;
 	overflow: scroll;
 }
 


### PR DESCRIPTION
I redesign of the selecting users to be most closely with the @Clementine46 's mockups.

The @Clementine46 's mockup :

![13 Espace A Ajout utilisateur 3-2](https://user-images.githubusercontent.com/28636549/135244070-375a2a9e-eb6a-4c17-ab14-941042fad859.png)

Now :

![image](https://user-images.githubusercontent.com/28636549/135244184-325115b5-5501-4d9b-9c1a-db11c9e027be.png)

Before :

![image](https://user-images.githubusercontent.com/28636549/135244876-b8e2674b-99e3-4ed5-9c28-ced436b2ebb8.png)

When I add users from Space :

![select-users-redesign-space](https://user-images.githubusercontent.com/28636549/135244374-bc9104d8-eef0-43df-afe0-7ebd39762d51.gif)

When I add users from subgroup :

![select-users-redesign-subgroup](https://user-images.githubusercontent.com/28636549/135244421-3f1f5221-ca59-4f17-b321-d1035f956cc2.gif)

When I add users from Space with a screen resolution 1280*1024 :

![select-users-redesign-space-1280-1024](https://user-images.githubusercontent.com/28636549/135244435-5040d8e7-0d79-44ce-9f53-adf19d3c0705.gif)

What do you think @Clementine46 ?

