### PR TITLE
fix(Vue, JS): Change functions to add users and add icons if they are member

### DIFF
--- a/src/SelectUsers.vue
+++ b/src/SelectUsers.vue
@@ -39,9 +39,9 @@
 				<div v-for="user in allSelectedUsers"
 					:key="user.name"
 					class="user-entry"
-					:class="$store.getters.isMember($route.params.space, user, $route.params.group) ? '' : 'user-not-member'">
+					:class="$store.getters.isMember($route.params.space, user) || !$route.params.group ? '' : 'user-not-member'">
 					<div>
-						<div class="icon-member" :class="$store.getters.addIconMember($route.params.space, user) ? 'is-member' : ''" />
+						<div class="icon-member" :class="$store.getters.isMember($route.params.space, user) ? 'is-member' : ''" />
 						<Avatar :display-name="user.name" :user="user.uid" />
 						<div class="user-name">
 							<span> {{ user.name }} </span>
@@ -106,7 +106,7 @@ export default {
 		// Returns true when at least 1 selected user is not yet member of the workspace
 		addingUsersToWorkspace() {
 			return !this.allSelectedUsers.every(user => {
-				return this.$store.getters.isMember(this.$route.params.space, user, this.$route.params.group)
+				return this.$store.getters.isMember(this.$route.params.space, user)
 			})
 		},
 	},
@@ -127,7 +127,7 @@ export default {
 			this.allSelectedUsers.forEach(user => {
 				let gid = ''
 				if (this.$route.params.group !== undefined) {
-					if (this.$store.getters.isMember(this.$route.params.space, user, this.$route.params.group)) {
+					if (this.$store.getters.isMember(this.$route.params.space, user)) {
 						if (user.role === 'user') {
 							this.$store.dispatch('removeUserFromGroup', {
 								name: this.$route.params.space,

--- a/src/store/getters.js
+++ b/src/store/getters.js
@@ -34,19 +34,8 @@ export const getters = {
 		}
 		return false
 	},
-	isMember: state => (name, user, group) => {
-		if (group === undefined) {
-			return true
-		}
-		const users = state.spaces[name].users
-		if (users.length === 0) {
-			return false
-		} else {
-			return (user.uid in users)
-		}
-	},
 	// Tests whether a user is member of workspace
-	addIconMember: state => (name, user) => {
+	isMember: state => (name, user) => {
 		const users = state.spaces[name].users
 		if (users.length === 0) {
 			return false


### PR DESCRIPTION
When we add users from space detail page. The users are highlighted. It's a problem in the algo from the isMember function.

@StCyr : Can you review my code today please ?

@LivOriona need to have this feature to do hers tests.

With this PR :

![select-users-highlight-fix](https://user-images.githubusercontent.com/28636549/136529038-be646bc8-51cd-47c2-9dcc-666fb43ece22.gif)

Before this PR : 

![select-users-highlight-before-fix](https://user-images.githubusercontent.com/28636549/136529289-54190c5e-56f2-4240-b1b7-0d102e91a0ed.gif)
