### PR TITLE
fix(l10b, Controller, Vue): Fix to print the special charcater message

### DIFF
--- a/l10n/en.js
+++ b/l10n/en.js
@@ -42,7 +42,7 @@ OC.L10N.register(
 		'No users': 'No users',
 		'Group name': 'Group name',
 		'Space name': 'Space name',
-		'Your Workspace name must not contain the following characters: [ ~ < > { } | ; . : , ! ? \' @ # $ + _ ( ) - % \\\\ ^ = / & * ]': 'Your Workspace name must not contain the following characters: [ ~ < > { } | ; . : , ! ? \' @ # $ + _ ( ) - % \\ ^ = / & * ]',
+		'Your Workspace name must not contain the following characters: [ ~ < > { } | ; . : , ! ? \' @ # $ + ( ) % \\\\ ^ = / & * ]': 'Your Workspace name must not contain the following characters: [ ~ < > { } | ; . : , ! ? \' @ # $ + ( ) % \\ ^ = / & * ]',
 		'There are no users in this space/group yet': 'There are no users in this space/group yet',
 		'Start typing to lookup users': 'Start typing to lookup users',
 		'remove users from selection': 'remove users from selection',

--- a/l10n/fr.js
+++ b/l10n/fr.js
@@ -41,7 +41,7 @@ OC.L10N.register(
 		'user': 'Utilisateur',
 		'Remove from group': 'Retirer du groupe',
 		'No users': 'Pas d\'utilisateur',
-		'Your Workspace name must not contain the following characters: [ ~ < > { } | ; . : , ! ? \' @ # $ + _ ( ) - % \\\\ ^ = / & * ]': 'Le nom de votre Espace de travail ne doit pas contenir les caractères suivants : [ ~ < > { } | ; . : , ! ? \' @ # $ + _ ( ) - % \\ ^ = / & * ]',
+		'Your Workspace name must not contain the following characters: [ ~ < > { } | ; . : , ! ? \' @ # $ + ( ) % \\\\ ^ = / & * ]': 'Le nom de votre Espace de travail ne doit pas contenir les caractères suivants : [ ~ < > { } | ; . : , ! ? \' @ # $ + ( ) % \\ ^ = / & * ]',
 		'There are no users in this space/group yet': 'Il n\'y a pas encore d\'utilisateur dans cet espace de travail',
 		'Start typing to lookup users': 'Commencez à saisir du texte pour rechercher des utilisateurs',
 		'remove users from selection': 'retirer l\'utilisateur de la sélection',

--- a/l10n/fr.json
+++ b/l10n/fr.json
@@ -37,7 +37,7 @@
 	"Workspace name" : "Nom de l'espace de travail",
 	"Remove from group": "Retirer du groupe",
 	"No users": "Pas d'utilisateur",
-	"Your Workspace name must not contain the following characters: [ ~ < > { } | ; . : , ! ? ' @ # $ + _ ( ) - % \\\\ ^ = / & * ]": "Le nom de votre Espace de travail ne doit pas contenir les caractères suivants : [ ~ < > { } | ; . : , ! ? ' @ # $ + _ ( ) - % \\\\ ^ = / & * ]",
+	"Your Workspace name must not contain the following characters: [ ~ < > { } | ; . : , ! ? ' @ # $ + ( ) % \\\\ ^ = / & * ]": "Le nom de votre Espace de travail ne doit pas contenir les caractères suivants : [ ~ < > { } | ; . : , ! ? ' @ # $ + ( ) % \\\\ ^ = / & * ]",
 	"No spaces": "Aucun espace de travail",
 	"You have not yet created any workspace": "Vous n'avez pas encore créé d'espace de travail",
 	"unlimited": "unlimited",

--- a/lib/Controller/WorkspaceController.php
+++ b/lib/Controller/WorkspaceController.php
@@ -101,10 +101,10 @@ class WorkspaceController extends Controller {
             throw new BadRequestException('spaceName must be provided');
         }
 
-        if (preg_match('/[~<>{}|;.:,!?\'@#$+_()-%\\\^=\/&*]/', $spaceName)) {
+        if (preg_match('/[~<>{}|;.:,!?\'@#$+()%\\\^=\/&*]/', $spaceName)) {
                 return new JSONResponse([
                     'statuscode' => Http::STATUS_BAD_REQUEST,
-                    'message' => 'Your Workspace name must not contain the following characters: [ ~ < > { } | ; . : , ! ? \' @ # $ + _ ( ) - % \ ^ = / & * ]',
+                    'message' => 'Your Workspace name must not contain the following characters: [ ~ < > { } | ; . : , ! ? \' @ # $ + ( ) - % \ ^ = / & * ]',
                 ]);
         }
 

--- a/src/Home.vue
+++ b/src/Home.vue
@@ -166,13 +166,13 @@ export default {
 				})
 				return
 			}
-			const pattern = '[~<>{}|;.:,!?\'@#$+_()\\-%\\\\^=/&*]'
+			const pattern = '[~<>{}|;.:,!?\'@#$+()%\\\\^=/&*]'
 			const regex = new RegExp(pattern)
 			if (regex.test(name)) {
 				console.debug(name)
 				this.$notify({
 					title: t('workspace', 'Error - Creating space'),
-					text: t('workspace', 'Your Workspace name must not contain the following characters: [ ~ < > { } | ; . : , ! ? \' @ # $ + _ ( ) - % \\\\ ^ = / & * ]'),
+					text: t('workspace', 'Your Workspace name must not contain the following characters: [ ~ < > { } | ; . : , ! ? \' @ # $ + ( ) % \\\\ ^ = / & * ]'),
 					duration: 6000,
 					type: 'error',
 				})


### PR DESCRIPTION
After input a spacename with the '()-_' and other specials characters, the error notify doesn't indicate them.

@StCyr : Can you review my PR ? I should merge for @LivOriona 's tests.

![create-space-special-chars](https://user-images.githubusercontent.com/28636549/136563343-f29edb82-d037-45e2-bf5e-3337d6d8dfdc.gif)

https://github.com/arawa/workspace/issues/339