### PR TITLE
build(Makefile): Ignore the dev dependancies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,6 +121,25 @@ source:
 	--exclude="../$(app_name)/node_modules" \
 	--exclude="../$(app_name)/*.log" \
 	--exclude="../$(app_name)/js/*.log" \
+	--exclude="../$(app_name)/README.md" \
+	--exclude="../$(app_name)/.vscode" \
+	--exclude="../$(app_name)/.github" \
+	--exclude="../$(app_name)/webpack.*.js" \
+	--exclude="../$(app_name)/tests" \
+	--exclude="../$(app_name)/src/tests" \
+	--exclude="../$(app_name)/phpunit.xml" \
+	--exclude="../$(app_name)/phpunit.integration.xml" \
+	--exclude="../$(app_name)/dependabot.yml" \
+	--exclude="../$(app_name)/notes" \
+	--exclude="../$(app_name)/babel.config.js" \
+	--exclude="../$(app_name)/composer.json" \
+	--exclude="../$(app_name)/composer.lock" \
+	--exclude="../$(app_name)/stylelint.config.js" \
+	--exclude="../$(app_name)/Makefile" \
+	--exclude="../$(app_name)/vendor" \
+	--exclude="../$(app_name)/COPYING" \
+	--exclude="../$(app_name)/package.json" \
+	--exclude="../$(app_name)/package-lock.json" \
 	../$(app_name)
 
 # Builds the source package for the app store, ignores php and js tests


### PR DESCRIPTION
These folders and files are ignored : 

- README.md
- .vscode
- .github
- webpack.*.js
- tests
- src/tests
- phpunit.xml
- phpunit.integration.xml
- dependabot.yml
- notes
- babel.config.js
- composer.json
- composer.lock
- stylelint.config.js
- Makefile
- vendor
- COPYING
- package.json
- package-lock.json

This change of build is following of a SysAdmin's remark.

@StCyr what is your opinion, please ? :slightly_smiling_face: 

I accept this PR after the @StCyr 's review only.

This step is very important to be accepted faster.