### PR TITLE
Searching users by email, name or uid

### DIFF
--- a/lib/Service/WorkspaceService.php
+++ b/lib/Service/WorkspaceService.php
@@ -65,6 +65,45 @@ class WorkspaceService {
 	}
 
 	/**
+	 * @param string $term
+	 * @return OCP\IUser[]
+	 */
+	private function searchUsersByMailing($term) {
+		return $this->userManager->getByEmail($term);
+	}
+
+	/**
+	 * @param string $term
+	 * @return OCP\IUser[]
+	 */
+	private function searchUsersByDisplayName($term) {
+		$users = [];
+
+		$term = $term === '*' ? '' : $term;
+		$users = $this->userManager->searchDisplayName($term, 50);
+
+		return $users;
+
+	}
+
+	/**
+	 * @param string $term
+	 * @return OCP\IUser[]
+	 */
+	private function searchUsers($term) {
+		$users = [];
+		$REGEX_FULL_MAIL = '/^[a-zA-Z0-9_.+-].+@[a-zA-Z0-9_.+-]/';
+
+		if (preg_match($REGEX_FULL_MAIL, $term) === 1 ) {
+			$users = $this->searchUsersByMailing($term);
+		} else {
+			$users = $this->searchUsersByDisplayName($term);
+		}
+
+		return $users;
+	}
+
+	/**
 	 * Returns a list of users whose name matches $term
 	 *
 	 * @param string $term
@@ -74,8 +113,7 @@ class WorkspaceService {
 	 */
 	public function autoComplete(string $term, array $space) {
 		// lookup users
-		$term = $term === '*' ? '' : $term;
-		$searchingUsers = $this->userManager->searchDisplayName($term, 50);
+		$searchingUsers = $this->searchUsers($term);
 
 		$users = [];
 		foreach($searchingUsers as $user) {

--- a/src/SelectUsers.vue
+++ b/src/SelectUsers.vue
@@ -33,6 +33,7 @@
 		</div>
 		<Multiselect class="select-users-input"
 			label="name"
+			:custom-label="displayForSearching"
 			track-by="uid"
 			:loading="isLookingUpUsers"
 			:multiple="false"
@@ -174,6 +175,9 @@ export default {
 					})
 				}
 			})
+		},
+		displayForSearching({ name, email, uid }) {
+			return `${name} - ${email} - ${uid}`
 		},
 		// Adds user to the batch when user selects user in the MultiSelect
 		addUserToBatch(user) {


### PR DESCRIPTION
From select users interface, we can search users suit email, name or uid.

# Demo

In this demo, I searched for users, in order, by uid, name and email.

![search-users-email-name-uid](https://user-images.githubusercontent.com/28636549/164485245-88a941e2-2a75-4d6a-9ee3-d7433d530610.gif)

@LivOriona what do you think ?