### PR TITLE
fix(PHP, Vue): A user who is a GE can create groups

### DIFF
--- a/lib/Controller/GroupController.php
+++ b/lib/Controller/GroupController.php
@@ -68,7 +68,7 @@ class GroupController extends Controller {
 	 * NB: This function could probably be abused by space managers to create arbitrary group. But, do we really care?
 	 *
 	 * @var string $gid
-	 * @var string $spaceId
+	 * @var string $spaceId for Middleware
 	 *
 	 * @return @JSONResponse
 	 */

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -89,7 +89,7 @@ export default {
 		context.commit('addGroupToSpace', { name, gid })
 
 		// Creates group in backend
-		axios.post(generateUrl(`/apps/workspace/api/group/${gid}`))
+		axios.post(generateUrl(`/apps/workspace/api/group/${gid}`), { spaceId: space.id })
 			.then((resp) => {
 				if (resp.status === 200) {
 					// add this group in groupfolders


### PR DESCRIPTION
I unintentionally deleted the spaceId as argument to create a group.

# Demo

![creating-group-with-ge](https://user-images.githubusercontent.com/28636549/164746363-9bab3b17-d01d-4f5a-9581-bdd9d243e9e5.gif)

It's okay for you @LivOriona ?