### PR TITLE
fix(Vue): Print the right quota

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27001,16 +27001,6 @@
       "resolved": "https://registry.npmjs.org/splitpanes/-/splitpanes-2.4.1.tgz",
       "integrity": "sha512-kpEo1WuMXuc6QfdQdO2V/fl/trONlkUKp+pputsLTiW9RMtwEvjb4/aYGm2m3+KAzjmb+zLwr4A4SYZu74+pgQ=="
     },
-    "splitpanes": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/splitpanes/-/splitpanes-2.4.1.tgz",
-      "integrity": "sha512-kpEo1WuMXuc6QfdQdO2V/fl/trONlkUKp+pputsLTiW9RMtwEvjb4/aYGm2m3+KAzjmb+zLwr4A4SYZu74+pgQ=="
-    },
-    "splitpanes": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/splitpanes/-/splitpanes-2.4.1.tgz",
-      "integrity": "sha512-kpEo1WuMXuc6QfdQdO2V/fl/trONlkUKp+pputsLTiW9RMtwEvjb4/aYGm2m3+KAzjmb+zLwr4A4SYZu74+pgQ=="
-    },
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -27898,16 +27888,6 @@
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
       "dev": true,
       "peer": true
-    },
-    "uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
-    },
-    "uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
     "uuid": {
       "version": "8.3.2",

--- a/src/Home.vue
+++ b/src/Home.vue
@@ -238,7 +238,7 @@ export default {
 		},
 		// Shows a space quota in a user-friendly way
 		convertQuotaForFrontend(quota) {
-			if (quota === -3) {
+			if (quota === -3 || quota === '-3') {
 				return 'unlimited'
 			} else {
 				const units = ['', 'KB', 'MB', 'GB', 'TB']

--- a/src/tests/unit/home.test.js
+++ b/src/tests/unit/home.test.js
@@ -70,6 +70,16 @@ describe('Home component tests', () => {
 		expect(quota).toEqual('23GB')
 	})
 
+	it('Convert -3 (int) to unlimited', () => {
+		const quota = wrappedHome.vm.convertQuotaForFrontend(-3)
+		expect(quota).toEqual('unlimited')
+	})
+
+	it('Convert -3 (string) to unlimited', () => {
+		const quota = wrappedHome.vm.convertQuotaForFrontend('-3')
+		expect(quota).toEqual('unlimited')
+	})
+
 	it('Return string type', () => {
 		const quota = wrappedHome.vm.convertQuotaForFrontend('10737418240')
 		expect(typeof (quota)).toBe('string')


### PR DESCRIPTION
This app must be compatible with Groupfolders < 10.X and > 10.X. And when we get a groupfolder, it returns the quota as an integer or a string.