### PR TITLE
Bugfix npm test

### DIFF
--- a/src/Home.vue
+++ b/src/Home.vue
@@ -26,7 +26,7 @@
 			position="top center"
 			width="50%"
 			class="notifications"
-			close-on-click="true" />
+			:close-on-click="true" />
 		<AppNavigation v-if="$root.$data.canAccessApp === 'true'">
 			<AppNavigationNewItem v-if="$root.$data.isUserGeneralAdmin === 'true'"
 				icon="icon-add"

--- a/src/router.js
+++ b/src/router.js
@@ -39,8 +39,7 @@ export default new Router({
 	routes: [
 		{
 			path: '/',
-			name: 'home',
-			component: Home,
+			component: resolve => resolve(Home),
 			children: [
 				{
 					path: '',

--- a/src/tests/unit/home.test.js
+++ b/src/tests/unit/home.test.js
@@ -21,20 +21,23 @@
  *
  */
 
-import { translate as t, translatePlural as n } from '@nextcloud/l10n'
 import { createLocalVue, mount } from '@vue/test-utils'
+import { createSpace } from '../../services/spaceService.js'
+import { translate as t, translatePlural as n } from '@nextcloud/l10n'
+import axios from '@nextcloud/axios'
 import Home from '../../Home.vue'
+import Notifications from 'vue-notification'
+import store from '../../store/index.js'
 import Vue from 'vue'
 import VueRouter from 'vue-router'
 import Vuex from 'vuex'
-import store from '../../store/index.js'
-import axios from '@nextcloud/axios'
-import { createSpace } from '../../services/spaceService'
 
 jest.mock('axios')
 
 Vue.prototype.t = t
 Vue.prototype.n = n
+
+Vue.use(Notifications)
 
 const localVue = createLocalVue()
 const router = new VueRouter()


### PR DESCRIPTION
Bug fix when I run `npm run test`.

```
$ npm run test

> workspace@1.0.0 test
> jest

 PASS  src/tests/unit/spaceService.test.js
  convertGroupfolderToSpace method
    ✓ Return object type (6 ms)
    ✓ Is not undefined (3 ms)

 PASS  src/tests/unit/store.test.js
  Vuex store tests
    ✓ Adds a space in the Vuex store (4 ms)
    ✓ Adds a group to the space (1 ms)
    ✓ Removes a group to the space (1 ms)
    ✓ Sets space quota
    ✓ Get space quota
    ✓ Adds a user to the space (1 ms)
    ✓ Count users in workspace (1 ms)
    ✓ Count users in group
    ✓ Removes a user from the space (1 ms)

  console.warn
    Proxying an event bus of version 3.0.2 with 1.3.0

       98 | import { ESPACE_MANAGERS_PREFIX, ESPACE_USERS_PREFIX, ESPACE_GID_PREFIX } from './constants'
       99 | import axios from '@nextcloud/axios'
    > 100 | import Avatar from '@nextcloud/vue/dist/Components/Avatar'
          | ^
      101 | import Actions from '@nextcloud/vue/dist/Components/Actions'
      102 | import ActionButton from '@nextcloud/vue/dist/Components/ActionButton'
      103 | import Multiselect from '@nextcloud/vue/dist/Components/Multiselect'

      at new ProxyBus (node_modules/@nextcloud/vue/node_modules/@nextcloud/auth/node_modules/@nextcloud/event-bus/dist/index.js:2341:15)
      at getBus (node_modules/@nextcloud/vue/node_modules/@nextcloud/auth/node_modules/@nextcloud/event-bus/dist/index.js:3318:12)
      at Object.<anonymous> (node_modules/@nextcloud/vue/node_modules/@nextcloud/auth/node_modules/@nextcloud/event-bus/dist/index.js:3324:11)
      at Object.<anonymous> (node_modules/@nextcloud/vue/node_modules/@nextcloud/auth/lib/requesttoken.ts:1:1)
      at Object.<anonymous> (node_modules/@nextcloud/vue/node_modules/@nextcloud/auth/lib/index.ts:1:1)
      at Object.require [as 3607] (node_modules/@nextcloud/vue/dist/Components/webpack:/NextcloudVue/external commonjs "@nextcloud/auth":1:18)
      at moduleId (node_modules/@nextcloud/vue/dist/Components/webpack:/NextcloudVue/webpack/bootstrap:19:22)
      at Object.gt [as 3351] (node_modules/@nextcloud/vue/dist/Components/webpack:/NextcloudVue/src/l10n.js:40:27)
      at moduleId (node_modules/@nextcloud/vue/dist/Components/webpack:/NextcloudVue/webpack/bootstrap:19:22)
      at node_modules/@nextcloud/vue/dist/Components/webpack:/NextcloudVue/src/components/Avatar/Avatar.vue?ac35:1:1
      at node_modules/@nextcloud/vue/dist/Components/webpack:/NextcloudVue/src/components/Avatar/Avatar.vue:24:33
      at node_modules/@nextcloud/vue/dist/Components/webpack:/NextcloudVue/src/components/Avatar/Avatar.vue:24:33
      at factory (node_modules/@nextcloud/vue/dist/Components/webpack:/NextcloudVue/webpack/universalModuleDefinition:3:20)
      at Object.<anonymous> (node_modules/@nextcloud/vue/dist/Components/webpack:/NextcloudVue/webpack/universalModuleDefinition:1:1)
      at src/SelectUsers.vue:100:1
      at Object.<anonymous> (src/SelectUsers.vue:210:3)
      at Object.<anonymous> (src/tests/unit/selectUsers.test.js:26:1)

  console.warn
    Proxying an event bus of version 3.0.2 with 2.1.1

       98 | import { ESPACE_MANAGERS_PREFIX, ESPACE_USERS_PREFIX, ESPACE_GID_PREFIX } from './constants'
       99 | import axios from '@nextcloud/axios'
    > 100 | import Avatar from '@nextcloud/vue/dist/Components/Avatar'
          | ^
      101 | import Actions from '@nextcloud/vue/dist/Components/Actions'
      102 | import ActionButton from '@nextcloud/vue/dist/Components/ActionButton'
      103 | import Multiselect from '@nextcloud/vue/dist/Components/Multiselect'

      at new warn (node_modules/@nextcloud/vue/node_modules/@nextcloud/event-bus/lib/ProxyBus.ts:17:21)
      at getBus (node_modules/@nextcloud/vue/node_modules/@nextcloud/event-bus/lib/index.ts:20:16)
      at Object.getBus (node_modules/@nextcloud/vue/node_modules/@nextcloud/event-bus/lib/index.ts:26:13)
      at Object.require [as 542] (node_modules/@nextcloud/vue/dist/Components/webpack:/NextcloudVue/external commonjs "@nextcloud/event-bus":1:18)
      at moduleId (node_modules/@nextcloud/vue/dist/Components/webpack:/NextcloudVue/webpack/bootstrap:19:22)
      at node_modules/@nextcloud/vue/dist/Components/webpack:/NextcloudVue/src/components/Avatar/Avatar.vue?ac35:1:1
      at node_modules/@nextcloud/vue/dist/Components/webpack:/NextcloudVue/src/components/Avatar/Avatar.vue:24:33
      at node_modules/@nextcloud/vue/dist/Components/webpack:/NextcloudVue/src/components/Avatar/Avatar.vue:24:33
      at factory (node_modules/@nextcloud/vue/dist/Components/webpack:/NextcloudVue/webpack/universalModuleDefinition:3:20)
      at Object.<anonymous> (node_modules/@nextcloud/vue/dist/Components/webpack:/NextcloudVue/webpack/universalModuleDefinition:1:1)
      at src/SelectUsers.vue:100:1
      at Object.<anonymous> (src/SelectUsers.vue:210:3)
      at Object.<anonymous> (src/tests/unit/selectUsers.test.js:26:1)

  console.warn
    Proxying an event bus of version 3.0.2 with 2.1.1

      93 | <script>
      94 | import axios from '@nextcloud/axios'
    > 95 | import AppContent from '@nextcloud/vue/dist/Components/AppContent'
         | ^
      96 | import AppContentDetails from '@nextcloud/vue/dist/Components/AppContentDetails'
      97 | import AppNavigation from '@nextcloud/vue/dist/Components/AppNavigation'
      98 | import AppNavigationIconBullet from '@nextcloud/vue/dist/Components/AppNavigationIconBullet'

      at new warn (node_modules/@nextcloud/vue/node_modules/@nextcloud/event-bus/lib/ProxyBus.ts:17:21)
      at getBus (node_modules/@nextcloud/vue/node_modules/@nextcloud/event-bus/lib/index.ts:20:16)
      at Object.getBus (node_modules/@nextcloud/vue/node_modules/@nextcloud/event-bus/lib/index.ts:26:13)
      at Object.542 (node_modules/@nextcloud/vue/dist/Components/webpack:/NextcloudVue/external commonjs "@nextcloud/event-bus":1:26)
      at exports (node_modules/@nextcloud/vue/dist/Components/webpack:/NextcloudVue/webpack/bootstrap:22:16)
      at node_modules/@nextcloud/vue/dist/Components/webpack:/NextcloudVue/src/components/AppContent/AppDetailsToggle.vue:33:1
      at node_modules/@nextcloud/vue/dist/Components/AppContent.js:1:73674
      at node_modules/@nextcloud/vue/dist/Components/AppContent.js:1:73679
      at node_modules/@nextcloud/vue/dist/Components/webpack:/NextcloudVue/webpack/universalModuleDefinition:4:28
      at Object.<anonymous> (node_modules/@nextcloud/vue/dist/Components/webpack:/NextcloudVue/webpack/universalModuleDefinition:11:1)
      at src/Home.vue:95:1
      at Object.<anonymous> (src/Home.vue:378:3)
      at Object.<anonymous> (src/tests/unit/home.test.js:28:1)

  console.warn
    Proxying an event bus of version 3.0.2 with 1.3.0

      74 | import Actions from '@nextcloud/vue/dist/Components/Actions'
      75 | import ActionButton from '@nextcloud/vue/dist/Components/ActionButton'
    > 76 | import ActionInput from '@nextcloud/vue/dist/Components/ActionInput'
         | ^
      77 | import Modal from '@nextcloud/vue/dist/Components/Modal'
      78 | import SelectUsers from './SelectUsers'
      79 | import UserTable from './UserTable'

      at new ProxyBus (node_modules/@nextcloud/logger/node_modules/@nextcloud/event-bus/dist/index.js:2341:15)
      at getBus (node_modules/@nextcloud/logger/node_modules/@nextcloud/event-bus/dist/index.js:3318:12)
      at Object.<anonymous> (node_modules/@nextcloud/logger/node_modules/@nextcloud/event-bus/dist/index.js:3324:11)
      at Object.<anonymous> (node_modules/@nextcloud/logger/node_modules/@nextcloud/auth/lib/requesttoken.ts:1:1)
      at Object.<anonymous> (node_modules/@nextcloud/logger/node_modules/@nextcloud/auth/lib/index.ts:1:1)
      at Object.<anonymous> (node_modules/@nextcloud/logger/lib/LoggerBuilder.ts:3:1)
      at Object.<anonymous> (node_modules/@nextcloud/logger/lib/index.ts:3:1)
      at Object.require [as 6251] (node_modules/@nextcloud/vue/dist/Components/webpack:/NextcloudVue/external commonjs "@nextcloud/logger":1:36)
      at moduleId (node_modules/@nextcloud/vue/dist/Components/webpack:/NextcloudVue/webpack/bootstrap:19:22)
      at Object.4069 (node_modules/@nextcloud/vue/dist/Components/webpack:/NextcloudVue/src/components/DatetimePicker/index.scss?021a:22:1)
      at moduleId (node_modules/@nextcloud/vue/dist/Components/webpack:/NextcloudVue/webpack/bootstrap:19:22)
      at node_modules/@nextcloud/vue/dist/Components/webpack:/NextcloudVue/src/components/ActionInput/ActionInput.vue?ba53:1:1
      at node_modules/@nextcloud/vue/dist/Components/webpack:/NextcloudVue/src/components/ActionInput/ActionInput.vue:24:33
      at node_modules/@nextcloud/vue/dist/Components/webpack:/NextcloudVue/src/components/ActionInput/ActionInput.vue:24:33
      at factory (node_modules/@nextcloud/vue/dist/Components/webpack:/NextcloudVue/webpack/universalModuleDefinition:3:20)
      at Object.<anonymous> (node_modules/@nextcloud/vue/dist/Components/webpack:/NextcloudVue/webpack/universalModuleDefinition:1:1)
      at src/GroupDetails.vue:76:1
      at Object.<anonymous> (src/GroupDetails.vue:168:3)
      at Object.<anonymous> (src/router.js:27:1)
      at Object.<anonymous> (src/store/actions.js:24:1)
      at Object.<anonymous> (src/store/index.js:26:1)
      at Object.<anonymous> (src/tests/unit/selectUsers.test.js:30:1)

  console.warn
    Proxying an event bus of version 3.0.2 with 1.3.0

      74 | import Actions from '@nextcloud/vue/dist/Components/Actions'
      75 | import ActionButton from '@nextcloud/vue/dist/Components/ActionButton'
    > 76 | import ActionInput from '@nextcloud/vue/dist/Components/ActionInput'
         | ^
      77 | import Modal from '@nextcloud/vue/dist/Components/Modal'
      78 | import SelectUsers from './SelectUsers'
      79 | import UserTable from './UserTable'

      at new ProxyBus (node_modules/@nextcloud/logger/node_modules/@nextcloud/event-bus/dist/index.js:2341:15)
      at getBus (node_modules/@nextcloud/logger/node_modules/@nextcloud/event-bus/dist/index.js:3318:12)
      at Object.<anonymous> (node_modules/@nextcloud/logger/node_modules/@nextcloud/event-bus/dist/index.js:3324:11)
      at Object.<anonymous> (node_modules/@nextcloud/logger/node_modules/@nextcloud/auth/lib/requesttoken.ts:1:1)
      at Object.<anonymous> (node_modules/@nextcloud/logger/node_modules/@nextcloud/auth/lib/index.ts:1:1)
      at Object.<anonymous> (node_modules/@nextcloud/logger/lib/LoggerBuilder.ts:3:1)
      at Object.<anonymous> (node_modules/@nextcloud/logger/lib/index.ts:3:1)
      at Object.require [as 6251] (node_modules/@nextcloud/vue/dist/Components/webpack:/NextcloudVue/external commonjs "@nextcloud/logger":1:36)
      at moduleId (node_modules/@nextcloud/vue/dist/Components/webpack:/NextcloudVue/webpack/bootstrap:19:22)
      at Object.4069 (node_modules/@nextcloud/vue/dist/Components/webpack:/NextcloudVue/src/components/DatetimePicker/index.scss?021a:22:1)
      at moduleId (node_modules/@nextcloud/vue/dist/Components/webpack:/NextcloudVue/webpack/bootstrap:19:22)
      at node_modules/@nextcloud/vue/dist/Components/webpack:/NextcloudVue/src/components/ActionInput/ActionInput.vue?ba53:1:1
      at node_modules/@nextcloud/vue/dist/Components/webpack:/NextcloudVue/src/components/ActionInput/ActionInput.vue:24:33
      at node_modules/@nextcloud/vue/dist/Components/webpack:/NextcloudVue/src/components/ActionInput/ActionInput.vue:24:33
      at factory (node_modules/@nextcloud/vue/dist/Components/webpack:/NextcloudVue/webpack/universalModuleDefinition:3:20)
      at Object.<anonymous> (node_modules/@nextcloud/vue/dist/Components/webpack:/NextcloudVue/webpack/universalModuleDefinition:1:1)
      at src/GroupDetails.vue:76:1
      at Object.<anonymous> (src/GroupDetails.vue:168:3)
      at Object.<anonymous> (src/router.js:27:1)
      at Object.<anonymous> (src/store/actions.js:24:1)
      at Object.<anonymous> (src/store/index.js:26:1)
      at Object.<anonymous> (src/tests/unit/home.test.js:30:1)

  console.debug
    Could not find capabilities initial state fall back to _oc_capabilities

      at debug (node_modules/@nextcloud/capabilities/lib/index.ts:7:11)

  console.debug
    Could not find capabilities initial state fall back to _oc_capabilities

      at debug (node_modules/@nextcloud/capabilities/lib/index.ts:7:11)

  console.warn
    Proxying an event bus of version 3.0.2 with 1.3.0

      74 | import Actions from '@nextcloud/vue/dist/Components/Actions'
      75 | import ActionButton from '@nextcloud/vue/dist/Components/ActionButton'
    > 76 | import ActionInput from '@nextcloud/vue/dist/Components/ActionInput'
         | ^
      77 | import Modal from '@nextcloud/vue/dist/Components/Modal'
      78 | import SelectUsers from './SelectUsers'
      79 | import UserTable from './UserTable'

      at new ProxyBus (node_modules/@nextcloud/vue/node_modules/@nextcloud/auth/node_modules/@nextcloud/event-bus/dist/index.js:2341:15)
      at getBus (node_modules/@nextcloud/vue/node_modules/@nextcloud/auth/node_modules/@nextcloud/event-bus/dist/index.js:3318:12)
      at Object.<anonymous> (node_modules/@nextcloud/vue/node_modules/@nextcloud/auth/node_modules/@nextcloud/event-bus/dist/index.js:3324:11)
      at Object.<anonymous> (node_modules/@nextcloud/vue/node_modules/@nextcloud/auth/lib/requesttoken.ts:1:1)
      at Object.<anonymous> (node_modules/@nextcloud/vue/node_modules/@nextcloud/auth/lib/index.ts:1:1)
      at Object.require [as 3607] (node_modules/@nextcloud/vue/dist/Components/webpack:/NextcloudVue/external commonjs "@nextcloud/auth":1:18)
      at moduleId (node_modules/@nextcloud/vue/dist/Components/webpack:/NextcloudVue/webpack/bootstrap:19:22)
      at Object.3351 (node_modules/@nextcloud/vue/dist/Components/webpack:/NextcloudVue/src/mixins/actionGlobal.js:56:70)
      at moduleId (node_modules/@nextcloud/vue/dist/Components/webpack:/NextcloudVue/webpack/bootstrap:19:22)
      at Object.4430 (node_modules/@nextcloud/vue/dist/Components/webpack:/NextcloudVue/src/components/Avatar/Avatar.vue?ac35:1:1)
      at moduleId (node_modules/@nextcloud/vue/dist/Components/webpack:/NextcloudVue/webpack/bootstrap:19:22)
      at Object.9378 (node_modules/@nextcloud/vue/dist/Components/webpack:/NextcloudVue/src/components/ListItemIcon/ListItemIcon.vue?8c0e:1:1)
      at moduleId (node_modules/@nextcloud/vue/dist/Components/webpack:/NextcloudVue/webpack/bootstrap:19:22)
      at Object.1471 (node_modules/@nextcloud/vue/dist/Components/webpack:/NextcloudVue/src/components/Multiselect/EllipsisedOption.vue:20:33)
      at moduleId (node_modules/@nextcloud/vue/dist/Components/webpack:/NextcloudVue/webpack/bootstrap:19:22)
      at Object.6251 (node_modules/@nextcloud/vue/dist/Components/webpack:/NextcloudVue/src/components/TimezonePicker/TimezonePicker.vue:69:1)
      at moduleId (node_modules/@nextcloud/vue/dist/Components/webpack:/NextcloudVue/webpack/bootstrap:19:22)
      at Object.4069 (node_modules/@nextcloud/vue/dist/Components/webpack:/NextcloudVue/src/components/DatetimePicker/index.scss?021a:22:1)
      at moduleId (node_modules/@nextcloud/vue/dist/Components/webpack:/NextcloudVue/webpack/bootstrap:19:22)
      at node_modules/@nextcloud/vue/dist/Components/webpack:/NextcloudVue/src/components/ActionInput/ActionInput.vue?ba53:1:1
      at node_modules/@nextcloud/vue/dist/Components/webpack:/NextcloudVue/src/components/ActionInput/ActionInput.vue:24:33
      at node_modules/@nextcloud/vue/dist/Components/webpack:/NextcloudVue/src/components/ActionInput/ActionInput.vue:24:33
      at factory (node_modules/@nextcloud/vue/dist/Components/webpack:/NextcloudVue/webpack/universalModuleDefinition:3:20)
      at Object.<anonymous> (node_modules/@nextcloud/vue/dist/Components/webpack:/NextcloudVue/webpack/universalModuleDefinition:1:1)
      at src/GroupDetails.vue:76:1
      at Object.<anonymous> (src/GroupDetails.vue:168:3)
      at Object.<anonymous> (src/router.js:27:1)
      at Object.<anonymous> (src/store/actions.js:24:1)
      at Object.<anonymous> (src/store/index.js:26:1)
      at Object.<anonymous> (src/tests/unit/home.test.js:30:1)

  console.debug
    Could not find capabilities initial state fall back to _oc_capabilities

      at debug (node_modules/@nextcloud/capabilities/lib/index.ts:7:11)

 PASS  src/tests/unit/selectUsers.test.js
  SelectUsers component tests
    ✓ addUsersToWorkspaceOrGroup test: Adding a user to a subgroup (62 ms)
    ✓ addUsersToWorkspaceOrGroup test: Adding a user to a workspace (34 ms)
    ✓ addUsersToWorkspaceOrGroup test: Adding a user to a workspace with admin role (30 ms)

  console.info
    [INFO] AppContent: falling back to global nextcloud pane config

      at VueComponent.paneConfigID (node_modules/@nextcloud/vue/dist/Components/webpack:/NextcloudVue/src/components/AppContent/AppContent.vue:216:1)

 PASS  src/tests/unit/home.test.js
  Home component tests
    ✓ ConvertQuotaForFrontend: Test regular quota (4 ms)
    ✓ ConvertQuotaForFrontend: Test unlimited quota
    ✓ Convert 10000MB to 10GB
    ✓ Convert 23GB to 23GB (1 ms)
    ✓ Convert -3 (int) to unlimited
    ✓ Convert -3 (string) to unlimited (1 ms)
    ✓ Return string type (1 ms)
  Creating spaces with different entries
    ✓ Home.methods.createSpace has been called (3 ms)
    ✓ Create "Sri_Lanka" (2 ms)

Test Suites: 4 passed, 4 total
Tests:       23 passed, 23 total
Snapshots:   0 total
Time:        5.135 s
Ran all test suites.
```

It's the best result I can get.

To understand why I have a problem with the release event-bus of Nextcloud : https://help.nextcloud.com/t/2-problems-when-i-run-npm-test/150058