### PR TITLE
fix to the issue with creating a usergroup from workpace interface

### DIFF
--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -101,7 +101,10 @@ export default {
 				console.log('Group ' + gid + ' created')
 			})
 			.catch((e) => {
-				context.commit('removeGroupFromSpace', { name, gid })
+				// get 403 status if usergroup already exists
+				if (e.response.status !== 403) {
+					context.commit('removeGroupFromSpace', { name, gid })
+				}
 				this._vm.$notify({
 					title: t('workspace', 'Network error'),
 					text: t('workspace', 'A network error occured while trying to create group ') + gid + t('workspace', '<br>The error is: ') + e,


### PR DESCRIPTION
When user tries to create a usergroup with a name that already exist, the corresponding usergroup disappears from a list of usergroups. This commit fixes this issue by adding condition that checks response status of the axios.post function if it is 403 the removeGroupFromSpace function won't be called and so the corresponding usergroup staus on the page