### PR TITLE
Remove the space id in the title

### DIFF
--- a/src/SpaceDetails.vue
+++ b/src/SpaceDetails.vue
@@ -134,7 +134,7 @@ export default {
 	computed: {
 		// The title to display at the top of the page
 		title() {
-			return this.$route.params.space + ' [ID: ' + this.$store.state.spaces[this.$route.params.space].id + ']'
+			return this.$route.params.space
 		},
 	},
 	created() {


### PR DESCRIPTION
I removed the space id between brackets in the title.

![image](https://user-images.githubusercontent.com/28636549/234920805-fdf00170-f131-4df2-8907-c4b2f642c2fb.png)
