### PR TITLE
Fix/modal window hide

### DIFF
--- a/src/SpaceDetails.vue
+++ b/src/SpaceDetails.vue
@@ -41,7 +41,7 @@
 			</div>
 			<div class="space-actions">
 				<div>
-					<NcActions default-icon="icon-add">
+					<NcActions ref="ncAction" default-icon="icon-add">
 						<NcActionButton icon="icon-user"
 							:close-after-click="true"
 							class="no-bold"
@@ -87,10 +87,10 @@
 			<SelectUsers :space-name="$route.params.space" @close="toggleShowSelectUsersModal" />
 		</NcModal>
 		<NcModal v-if="showDelWorkspaceModal"
-      style="min-heigth: 8rem;"
-      size="small"
-		  @close="toggleShowDelWorkspaceModal">
-		  <RemoveSpace :space-name="$route.params.space" @handle-cancel="toggleShowDelWorkspaceModal" @handle-delete="deleteSpace" />
+			style="min-heigth: 8rem;"
+			size="small"
+			@close="toggleShowDelWorkspaceModal">
+			<RemoveSpace :space-name="$route.params.space" @handle-cancel="toggleShowDelWorkspaceModal" @handle-delete="deleteSpace" />
 		</NcModal>
 	</div>
 </template>
@@ -127,7 +127,7 @@ export default {
 			createGroup: false, // true to display 'Create Group' ActionInput
 			renameSpace: false, // true to display 'Rename space' ActionInput
 			showSelectUsersModal: false, // true to display user selection Modal windows
-			showDelWorkspaceModal: false,
+			showSpaceMenu: false,
 			isESR: false,
 		}
 	},
@@ -162,6 +162,8 @@ export default {
 		onNewGroup(e) {
 			// Hides ActionInput
 			this.toggleCreateGroup()
+			// Hide popup menu
+			this.$refs.ncAction.closeMenu()
 
 			// Don't accept empty names
 			const gid = e.target[0].value
@@ -329,6 +331,6 @@ export default {
 	flex-flow: row-reverse;
 }
 .modal-wrapper--small .modal-container {
-  min-height: 12rem !important;
+	min-height: 12rem !important;
 }
 </style>

--- a/src/SpaceDetails.vue
+++ b/src/SpaceDetails.vue
@@ -163,7 +163,7 @@ export default {
 			// Hides ActionInput
 			this.toggleCreateGroup()
 			// Hide popup menu
-			this.$refs.ncAction.closeMenu()
+			this.$refs.ncAction.opened = false
 
 			// Don't accept empty names
 			const gid = e.target[0].value


### PR DESCRIPTION
when user submits a not valid usergroup name the corresponding error appears, it is covered by popover menu of the NcActions component. This PR fixes this bug with the use of _ref_ and _opened_ props 