### PR TITLE
chore(): Update the release to 4.0.0-beta

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -5,7 +5,7 @@
 
     <name>Workspace</name>
 
-    <version>3.0.0</version>
+    <version>4.0.0-beta</version>
 
     <licence>agpl</licence>
 
@@ -20,7 +20,7 @@
 
     <bugs>https://www.arawa.fr/contact/</bugs>
     <dependencies>
-        <nextcloud min-version="26" max-version="26"/>
+        <nextcloud min-version="27" max-version="28"/>
     </dependencies>
 
     <summary>Create Groupfolders with delegated management</summary>


### PR DESCRIPTION
I updated the release to 4.0.0-beta and works with NC27 (min) and NC28 (max).