### PR TITLE
fix(vue): remove not used variable and replace by a proper one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix workspace removal issue ( [#838](https://github.com/arawa/workspace/pull/838))
+
 ## [3.0.0] - 2023-05-25
 
 ### Added

--- a/docs/dev/CHANGELOG.md
+++ b/docs/dev/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix workspace removal issue ( [#838](https://github.com/arawa/workspace/pull/838))
+
 ## [3.0.0] - 2023-05-25
 
 ### Added

--- a/src/SpaceDetails.vue
+++ b/src/SpaceDetails.vue
@@ -128,7 +128,7 @@ export default {
 			createGroup: false, // true to display 'Create Group' ActionInput
 			renameSpace: false, // true to display 'Rename space' ActionInput
 			showSelectUsersModal: false, // true to display user selection Modal windows
-			showSpaceMenu: false,
+			showDelWorkspaceModal: false,
 			isESR: false,
 		}
 	},


### PR DESCRIPTION
This fix is to PR #801, there was an error caused by wrong variable name ShowSpaceMenu instead of ShowDelWorkspaceModal. This resulted in an issue with space removal, when clicking on "Delete Worskapce" menu item the modal window didn't open.