### PR TITLE
hide modal window menu when there is an error message 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Close menu on group rename error message ([#839](https://github.com/arawa/workspace/pull/839))
+
 ## [3.0.0] - 2023-05-25
 
 ### Added

--- a/docs/dev/CHANGELOG.md
+++ b/docs/dev/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Close menu on group rename error message ([#839](https://github.com/arawa/workspace/pull/839))
+
 ## [3.0.0] - 2023-05-25
 
 ### Added

--- a/src/GroupDetails.vue
+++ b/src/GroupDetails.vue
@@ -1,23 +1,23 @@
 <!--
-  @copyright Copyright (c) 2017 Arawa
+	@copyright Copyright (c) 2017 Arawa
 
-  @author 2021 Baptiste Fotia <baptiste.fotia@arawa.fr>
-  @author 2021 Cyrille Bollu <cyrille@bollu.be>
+	@author 2021 Baptiste Fotia <baptiste.fotia@arawa.fr>
+	@author 2021 Cyrille Bollu <cyrille@bollu.be>
 
-  @license GNU AGPL version 3 or any later version
+	@license GNU AGPL version 3 or any later version
 
-  This program is free software: you can redistribute it and/or modify
-  it under the terms of the GNU Affero General Public License as
-  published by the Free Software Foundation, either version 3 of the
-  License, or (at your option) any later version.
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU Affero General Public License as
+	published by the Free Software Foundation, either version 3 of the
+	License, or (at your option) any later version.
 
-  This program is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  GNU Affero General Public License for more details.
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU Affero General Public License for more details.
 
-  You should have received a copy of the GNU Affero General Public License
-  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+	You should have received a copy of the GNU Affero General Public License
+	along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 
 <template>
@@ -39,7 +39,7 @@
 						</NcActionButton>
 					</NcActions>
 				</div>
-				<NcActions>
+				<NcActions ref="ncAction">
 					<NcActionButton v-if="!$store.getters.isGEorUGroup($route.params.space, $route.params.group)"
 						v-show="!showRenameGroupInput"
 						icon="icon-rename"
@@ -112,6 +112,7 @@ export default {
 		onRenameGroup(e) {
 			// Hides NcActionInput
 			this.toggleShowRenameGroupInput()
+			this.$refs.ncAction.opened = false
 
 			// Don't accept empty names
 			const group = e.target[0].value


### PR DESCRIPTION
This PR is intended to fix a minor bug of the UI: wWhen trying to rename a user group and there is an error message the modal window continue to be present on the page. This is fixed with adding ref to corresponding component and then call 'this.$refs.ncAction.opened=false'.