### PR TITLE
hotfix(php): Ignore guest virtual group

### DIFF
--- a/lib/Upgrade/UpgradeV300.php
+++ b/lib/Upgrade/UpgradeV300.php
@@ -28,6 +28,7 @@ use OCA\Workspace\Db\GroupFoldersGroupsMapper;
 use OCA\Workspace\Db\SpaceMapper;
 use OCA\Workspace\Service\Group\UserGroup;
 use OCA\Workspace\Service\Group\WorkspaceManagerGroup;
+use OCA\Workspace\Upgrade\Upgrade;
 use OCP\AppFramework\Services\IAppConfig;
 use OCP\IGroupManager;
 
@@ -73,6 +74,9 @@ class UpgradeV300 implements UpgradeInterface {
 
 	private function changePrefixForWorkspaceManagerGroups(): void {
 		$workspaceManagerGroups = $this->groupManager->search(WorkspaceManagerGroup::getPrefix());
+        $workspaceManagerGroups = array_filter($workspaceManagerGroups, function ($group) {
+            return !in_array('OCA\\Guests\\GroupBackend', $group->getBackendNames());
+        });
 		foreach ($workspaceManagerGroups as $group) {
 			$groupname = $group->getGID();
 			$groupnameSplitted = explode('-', $groupname);
@@ -86,6 +90,9 @@ class UpgradeV300 implements UpgradeInterface {
 
 	private function changePrefixForWorkspaceUserGroups(): void {
 		$userGroups = $this->groupManager->search(UserGroup::getPrefix());
+        $userGroups = array_filter($userGroups, function ($group) {
+            return !in_array('OCA\\Guests\\GroupBackend', $group->getBackendNames());
+        });
 		foreach ($userGroups as $group) {
 			$groupname = $group->getGID();
 			$groupnameSplitted = explode('-', $groupname);


### PR DESCRIPTION
When we run the update of Workspace to 3.0.X, the migration is stopped and the program doesn't change the display name of Workspace's groups.

Why ? Because, when we use the "search" function from "IGroupManager", by default, in addition to groups beginning with "SPACE-GE" or "SPACE-U", we get the guest virtual group.

So, the solution is to use the "array_filter" to ignore the "OCA\\Guests\\GroupBackend" backendname.