### PR TITLE
fix(Vue,Php): Rename the groups with the spacename

### DIFF
--- a/lib/Controller/GroupController.php
+++ b/lib/Controller/GroupController.php
@@ -145,29 +145,20 @@ class GroupController extends Controller {
 	public function rename(string $newGroupName,
 		string $gid,
 		int $spaceId): JSONResponse {
+        $groups = $this->groupManager->search($newGroupName);
+        $groups = array_filter($groups, function($group) {
+            return str_starts_with($group->getGID(), 'SPACE-GE-') 
+                || str_starts_with($group->getGID(), 'SPACE-U-') 
+                || str_starts_with($group->getGID(), 'SPACE-G-');
+        });
 
-		if (!empty($this->groupManager->search($newGroupName))) {
+		if (!empty($groups)) {
 			return new JSONResponse(
 				'This group already exists. Please, change the name',
 				Http::STATUS_CONFLICT
 			);
 		}
 		
-		// TODO Use groupfolder api to retrieve workspace group.
-		if (substr($gid, -strlen($spaceId)) != $spaceId) {
-			return new JSONResponse(
-				['You may only rename workspace groups of this space (ie: group\'s name does not end by the workspace\'s ID)'],
-				Http::STATUS_FORBIDDEN
-			);
-		}
-
-		if (substr($newGroupName, -strlen($spaceId)) != $spaceId) {
-			return new JSONResponse(
-				['Workspace groups must ends with the ID of the space they belong to'],
-				Http::STATUS_FORBIDDEN
-			);
-		}
-
 		// Rename group
 		$NCGroup = $this->groupManager->get($gid);
 		if (is_null($NCGroup)) {

--- a/lib/Controller/GroupController.php
+++ b/lib/Controller/GroupController.php
@@ -145,12 +145,12 @@ class GroupController extends Controller {
 	public function rename(string $newGroupName,
 		string $gid,
 		int $spaceId): JSONResponse {
-        $groups = $this->groupManager->search($newGroupName);
-        $groups = array_filter($groups, function($group) {
-            return str_starts_with($group->getGID(), 'SPACE-GE-') 
-                || str_starts_with($group->getGID(), 'SPACE-U-') 
-                || str_starts_with($group->getGID(), 'SPACE-G-');
-        });
+		$groups = $this->groupManager->search($newGroupName);
+		$groups = array_filter($groups, function ($group) {
+			return str_starts_with($group->getGID(), 'SPACE-GE-')
+				|| str_starts_with($group->getGID(), 'SPACE-U-')
+				|| str_starts_with($group->getGID(), 'SPACE-G-');
+		});
 
 		if (!empty($groups)) {
 			return new JSONResponse(

--- a/src/GroupDetails.vue
+++ b/src/GroupDetails.vue
@@ -114,13 +114,17 @@ export default {
 			this.toggleShowRenameGroupInput()
 
 			// Don't accept empty names
-			const group = e.target[0].value
+			let group = e.target[0].value
 			if (!group) {
 				// TODO Inform user
 				return
 			}
 
 			const space = this.$store.state.spaces[this.$route.params.space]
+			const groupSpace = space.groups[this.$route.params.group]
+
+			group = ''.concat('G-', group, '-', space.name)
+			group = groupSpace.displayName.replace(groupSpace.displayName, group)
 
 			// Prevents renaming SPACE-GE- and SPACE-U- groups
 			if (group === PREFIX_MANAGER + space.id

--- a/src/SpaceDetails.vue
+++ b/src/SpaceDetails.vue
@@ -109,8 +109,6 @@ import RemoveSpace from './RemoveSpace.vue'
 import UserTable from './UserTable.vue'
 import { destroy, rename, checkGroupfolderNameExist } from './services/groupfoldersService.js'
 import showNotificationError from './services/Notifications/NotificationError.js'
-import ManagerGroup from './services/Groups/ManagerGroup'
-import UserGroup from './services/Groups/UserGroup'
 
 export default {
 	name: 'SpaceDetails',

--- a/src/SpaceDetails.vue
+++ b/src/SpaceDetails.vue
@@ -109,6 +109,8 @@ import RemoveSpace from './RemoveSpace.vue'
 import UserTable from './UserTable.vue'
 import { destroy, rename, checkGroupfolderNameExist } from './services/groupfoldersService.js'
 import showNotificationError from './services/Notifications/NotificationError.js'
+import ManagerGroup from './services/Groups/ManagerGroup'
+import UserGroup from './services/Groups/UserGroup'
 
 export default {
 	name: 'SpaceDetails',
@@ -203,6 +205,21 @@ export default {
 				this.$store.dispatch('removeSpace', {
 					space: this.$store.state.spaces[oldSpaceName],
 				})
+
+				const groupKeys = Object.keys(space.groups)
+
+				groupKeys.forEach(key => {
+					const group = space.groups[key]
+					const newDisplayName = group.displayName.replace(oldSpaceName, newSpaceName)
+
+					// Renames group
+					this.$store.dispatch('renameGroup', {
+					  name: newSpaceName,
+					  gid: group.gid,
+					  newGroupName: newDisplayName,
+					})
+				})
+
 				this.$router.push({
 					path: `/workspace/${space.name}`,
 				})

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -192,9 +192,6 @@ export default {
 	renameGroup(context, { name, gid, newGroupName }) {
 		const space = context.state.spaces[name]
 
-		// Groups must be postfixed with the ID of the space they belong
-		newGroupName = `${PREFIX_DISPLAYNAME_SUBGROUP_SPACE}${newGroupName}-${space.name}`
-
 		// Creates group in backend
 		axios.patch(generateUrl(`/apps/workspace/api/group/${gid}`), { spaceId: space.id, newGroupName })
 			.then((resp) => {


### PR DESCRIPTION
Now, when we will rename one space, all groups (even WM- and U-) will be changed with the new space name.

If one group is renamed, it will be suffixed and prefixed with G- and the space name.

@acdmft can you review and test my code, please ?

This PR will be backported to stable3.0 .