### PR TITLE
GeneralManager is able to add users to WM-

### DIFF
--- a/lib/Service/WorkspaceService.php
+++ b/lib/Service/WorkspaceService.php
@@ -26,6 +26,7 @@
 namespace OCA\Workspace\Service;
 
 use OCA\Workspace\Db\SpaceMapper;
+use OCA\Workspace\Service\Group\ManagersWorkspace;
 use OCA\Workspace\Service\Group\UserGroup;
 use OCA\Workspace\Service\Group\WorkspaceManagerGroup;
 use OCP\IGroupManager;
@@ -43,7 +44,8 @@ class WorkspaceService {
 		private IUserSession $userSession,
 		private LoggerInterface $logger,
 		private SpaceMapper $spaceMapper,
-		private UserService $userService
+		private UserService $userService,
+        private IUserSession $userSession
 	) {
 	}
 
@@ -123,7 +125,11 @@ class WorkspaceService {
 			}
 		}
 
-		if ($this->shareManager->shareWithGroupMembersOnly()) {
+		if ($this->shareManager->shareWithGroupMembersOnly() 
+            && !$this->groupManager->isInGroup(
+                $this->userSession->getUser()->getUID(),
+                ManagersWorkspace::GENERAL_MANAGER)
+            ) {
 			$users = $this->getUsersFromGroupsOnly($users);
 		}
 


### PR DESCRIPTION
If the "share with gorup members only" is checked, the GeneralManager is not able to add users to the Workspace Manager group.

@smarinier, don't accept my PR for the moment, please :pray: 

I didn't test it yet ^^'