### PR TITLE
Create spaceitem and groupitem components

### DIFF
--- a/css/workspace-style.css
+++ b/css/workspace-style.css
@@ -69,3 +69,7 @@ tr:hover {
 	font-size: 20px;
 	margin-top: 10px;
 }
+
+.user-counter {
+	margin-right: 5px;
+}

--- a/src/GroupMenuItem.vue
+++ b/src/GroupMenuItem.vue
@@ -1,0 +1,37 @@
+<template>
+	<NcAppNavigationItem
+		icon="icon-group"
+		:to="{path: `/group/${spaceName}/${group.gid}`}"
+		:title="group.displayName">
+		<NcCounterBubble slot="counter" class="user-counter">
+			{{ $store.getters.groupUserCount( spaceName, group.gid) }}
+		</NcCounterBubble>
+	</NcAppNavigationItem>
+</template>
+
+<script>
+import NcAppNavigationItem from '@nextcloud/vue/dist/Components/NcAppNavigationItem.js'
+import NcCounterBubble from '@nextcloud/vue/dist/Components/NcCounterBubble.js'
+
+export default {
+	name: 'GroupMenuItem',
+	components: {
+		NcAppNavigationItem,
+		NcCounterBubble,
+	},
+	props: {
+		group: {
+			type: Object,
+			required: true,
+		},
+		spaceName: {
+			type: String,
+			required: true,
+
+		},
+	},
+}
+</script>
+
+<style>
+</style>

--- a/src/LeftSidebar.vue
+++ b/src/LeftSidebar.vue
@@ -30,31 +30,11 @@
 			:to="{path: '/'}"
 			:class="$route.path === '/' ? 'space-selected' : 'all-spaces'" />
 		<template #list>
-			<NcAppNavigationItem
+			<SpaceMenuItem
 				v-for="(space, spaceName) in $store.state.spaces"
 				:key="space.id"
-				:class="$route.params.space === spaceName ? 'space-selected' : ''"
-				:allow-collapse="true"
-				:open="$route.params.space === spaceName"
-				:title="spaceName"
-				:to="{path: `/workspace/${spaceName}`}">
-				<NcAppNavigationIconBullet slot="icon" :color="space.color" />
-				<NcCounterBubble slot="counter" class="user-counter">
-					{{ $store.getters.spaceUserCount(spaceName) }}
-				</NcCounterBubble>
-				<div>
-					<NcAppNavigationItem
-						v-for="group in sortedGroups(Object.values(space.groups), spaceName)"
-						:key="group.gid"
-						icon="icon-group"
-						:to="{path: `/group/${spaceName}/${group.gid}`}"
-						:title="group.displayName">
-						<NcCounterBubble slot="counter" class="user-counter">
-							{{ $store.getters.groupUserCount( spaceName, group.gid) }}
-						</NcCounterBubble>
-					</NcAppNavigationItem>
-				</div>
-			</NcAppNavigationItem>
+				:space="space"
+				:space-name="spaceName" />
 			<!-- <div id="app-settings">
 					<div id="app-settings-header">
 						<button v-if="$root.$data.isUserGeneralAdmin === 'true'"
@@ -76,25 +56,23 @@
 </template>
 
 <script>
-import { createSpace, deleteBlankSpacename, isSpaceManagers, isSpaceUsers } from './services/spaceService.js'
 import { createGroupfolder, checkGroupfolderNameExist, enableAcl, addGroupToGroupfolder, addGroupToManageACLForGroupfolder } from './services/groupfoldersService.js'
+import { createSpace, deleteBlankSpacename, isSpaceManagers, isSpaceUsers } from './services/spaceService.js'
 import { PATTERN_CHECK_NOTHING_SPECIAL_CHARACTER } from './constants.js'
 import BadCreateError from './Errors/BadCreateError.js'
 import NcAppNavigation from '@nextcloud/vue/dist/Components/NcAppNavigation.js'
-import NcAppNavigationNewItem from '@nextcloud/vue/dist/Components/NcAppNavigationNewItem.js'
-import NcAppNavigationIconBullet from '@nextcloud/vue/dist/Components/NcAppNavigationIconBullet.js'
 import NcAppNavigationItem from '@nextcloud/vue/dist/Components/NcAppNavigationItem.js'
-import NcCounterBubble from '@nextcloud/vue/dist/Components/NcCounterBubble.js'
-import { getLocale } from '@nextcloud/l10n'
+import NcAppNavigationNewItem from '@nextcloud/vue/dist/Components/NcAppNavigationNewItem.js'
 import showNotificationError from './services/Notifications/NotificationError.js'
+import SpaceMenuItem from './SpaceMenuItem.vue'
+
 export default {
 	name: 'LeftSidebar',
 	components: {
 		NcAppNavigation,
 		NcAppNavigationNewItem,
 		NcAppNavigationItem,
-		NcAppNavigationIconBullet,
-		NcCounterBubble,
+		SpaceMenuItem,
 	},
 	methods: {
 		// Creates a new space and navigates to its details page
@@ -145,43 +123,6 @@ export default {
 				path: `/workspace/${name}`,
 			})
 		},
-		// sorts groups alphabetically
-		sortedGroups(groups, space) {
-			groups.sort((a, b) => {
-				// Makes sure the GE- group is first in the list
-				// These tests must happen before the tests for the U- group
-				const GEGroup = this.$store.getters.GEGroup(space)
-				if (a.gid === GEGroup) {
-					return -1
-				}
-				if (b.gid === GEGroup) {
-					return 1
-				}
-				// Makes sure the U- group is second in the list
-				// These tests must be done after the tests for the GE- group
-				const UGroup = this.$store.getters.UGroup(space)
-				if (a.gid === UGroup) {
-					return -1
-				}
-				if (b.gid === UGroup) {
-					return 1
-				}
-				// Normal locale based sort
-				// Some javascript engines don't support localCompare's locales
-				// and options arguments.
-				// This is especially the case of the mocha test framework
-				try {
-					return a.displayName.localeCompare(b.displayName, getLocale(), {
-						sensitivity: 'base',
-						ignorePunctuation: true,
-					})
-				} catch (e) {
-					return a.displayName.localeCompare(b.displayName)
-				}
-			})
-
-			return groups
-		},
 	},
 }
 </script>
@@ -189,8 +130,5 @@ export default {
 <style scoped>
 .app-navigation-entry {
 	padding-right: 0px;
-}
-.user-counter {
-	margin-right: 5px;
 }
 </style>

--- a/src/SpaceMenuItem.vue
+++ b/src/SpaceMenuItem.vue
@@ -1,0 +1,117 @@
+<!--
+	@copyright Copyright (c) 2017 Arawa
+
+	@author 2023 Baptiste Fotia <baptiste.fotia@arawa.fr>
+
+	@license GNU AGPL version 3 or any later version
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU Affero General Public License as
+	published by the Free Software Foundation, either version 3 of the
+	License, or (at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU Affero General Public License for more details.
+
+	You should have received a copy of the GNU Affero General Public License
+	along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
+<template>
+	<NcAppNavigationItem
+		:key="space.id"
+		:class="$route.params.space === spaceName ? 'space-selected' : ''"
+		:allow-collapse="true"
+		:open="$route.params.space === spaceName"
+		:title="spaceName"
+		:to="{path: `/workspace/${spaceName}`}">
+		<NcAppNavigationIconBullet slot="icon" :color="space.color" />
+		<NcCounterBubble slot="counter" class="user-counter">
+			{{ $store.getters.spaceUserCount(spaceName) }}
+		</NcCounterBubble>
+		<div>
+			<NcAppNavigationItem
+				v-for="group in sortedGroups(Object.values(space.groups), spaceName)"
+				:key="group.gid"
+				icon="icon-group"
+				:to="{path: `/group/${spaceName}/${group.gid}`}"
+				:title="group.displayName">
+				<NcCounterBubble slot="counter" class="user-counter">
+					{{ $store.getters.groupUserCount( spaceName, group.gid) }}
+				</NcCounterBubble>
+			</NcAppNavigationItem>
+		</div>
+	</NcAppNavigationItem>
+</template>
+
+<script>
+import NcAppNavigationItem from '@nextcloud/vue/dist/Components/NcAppNavigationItem.js'
+import NcAppNavigationIconBullet from '@nextcloud/vue/dist/Components/NcAppNavigationIconBullet.js'
+import NcCounterBubble from '@nextcloud/vue/dist/Components/NcCounterBubble.js'
+import { getLocale } from '@nextcloud/l10n'
+
+export default {
+	name: 'SpaceMenuItem',
+	components: {
+		NcAppNavigationItem,
+		NcAppNavigationIconBullet,
+		NcCounterBubble,
+	},
+	props: {
+		space: {
+			type: Object,
+			required: true,
+		},
+		spaceName: {
+			type: String,
+			required: true,
+		},
+	},
+	methods: {
+		// sorts groups alphabetically
+		sortedGroups(groups, space) {
+			groups.sort((a, b) => {
+				// Makes sure the GE- group is first in the list
+				// These tests must happen before the tests for the U- group
+				const GEGroup = this.$store.getters.GEGroup(space)
+				if (a.gid === GEGroup) {
+					return -1
+				}
+				if (b.gid === GEGroup) {
+					return 1
+				}
+				// Makes sure the U- group is second in the list
+				// These tests must be done after the tests for the GE- group
+				const UGroup = this.$store.getters.UGroup(space)
+				if (a.gid === UGroup) {
+					return -1
+				}
+				if (b.gid === UGroup) {
+					return 1
+				}
+				// Normal locale based sort
+				// Some javascript engines don't support localCompare's locales
+				// and options arguments.
+				// This is especially the case of the mocha test framework
+				try {
+					return a.displayName.localeCompare(b.displayName, getLocale(), {
+						sensitivity: 'base',
+						ignorePunctuation: true,
+					})
+				} catch (e) {
+					return a.displayName.localeCompare(b.displayName)
+				}
+			})
+
+			return groups
+		},
+	},
+}
+</script>
+
+<style>
+.user-counter {
+	margin-right: 5px;
+}
+</style>

--- a/src/SpaceMenuItem.vue
+++ b/src/SpaceMenuItem.vue
@@ -31,31 +31,28 @@
 			{{ $store.getters.spaceUserCount(spaceName) }}
 		</NcCounterBubble>
 		<div>
-			<NcAppNavigationItem
+			<GroupMenuItem
 				v-for="group in sortedGroups(Object.values(space.groups), spaceName)"
 				:key="group.gid"
-				icon="icon-group"
-				:to="{path: `/group/${spaceName}/${group.gid}`}"
-				:title="group.displayName">
-				<NcCounterBubble slot="counter" class="user-counter">
-					{{ $store.getters.groupUserCount( spaceName, group.gid) }}
-				</NcCounterBubble>
-			</NcAppNavigationItem>
+				:group="group"
+				:space-name="spaceName" />
 		</div>
 	</NcAppNavigationItem>
 </template>
 
 <script>
-import NcAppNavigationItem from '@nextcloud/vue/dist/Components/NcAppNavigationItem.js'
-import NcAppNavigationIconBullet from '@nextcloud/vue/dist/Components/NcAppNavigationIconBullet.js'
-import NcCounterBubble from '@nextcloud/vue/dist/Components/NcCounterBubble.js'
 import { getLocale } from '@nextcloud/l10n'
+import GroupMenuItem from './GroupMenuItem.vue'
+import NcAppNavigationIconBullet from '@nextcloud/vue/dist/Components/NcAppNavigationIconBullet.js'
+import NcAppNavigationItem from '@nextcloud/vue/dist/Components/NcAppNavigationItem.js'
+import NcCounterBubble from '@nextcloud/vue/dist/Components/NcCounterBubble.js'
 
 export default {
 	name: 'SpaceMenuItem',
 	components: {
-		NcAppNavigationItem,
+		GroupMenuItem,
 		NcAppNavigationIconBullet,
+		NcAppNavigationItem,
 		NcCounterBubble,
 	},
 	props: {
@@ -111,7 +108,4 @@ export default {
 </script>
 
 <style>
-.user-counter {
-	margin-right: 5px;
-}
 </style>


### PR DESCRIPTION
This PR split the Space item from the LeftSidebar in 2 components : 

- SpaceMenuItem : It's the space item in the LeftSidebar where we list a space and its groups.

![image](https://github.com/arawa/workspace/assets/28636549/a21cc718-3906-4b4e-85fc-1cb135fafa9f)

- GroupMenuItem : It's the group item in the sub-menu of a space.

![image](https://github.com/arawa/workspace/assets/28636549/87a77a9c-0a0b-4ba0-bc28-72f2c6d03ae4)
