### PR TITLE
Prevent duplicate users_oidc

### DIFF
--- a/lib/Service/WorkspaceService.php
+++ b/lib/Service/WorkspaceService.php
@@ -65,6 +65,8 @@ class WorkspaceService {
 		$term = $term === '*' ? '' : $term;
 		$users = $this->userManager->searchDisplayName($term, 50);
 
+		$users = array_unique($users, SORT_REGULAR);
+
 		return $users;
 	}
 


### PR DESCRIPTION
This commit PR duplicate users when we search them with the `apps/workspace/api/autoComplete/:term/:spaceId` api/rest.