### PR TITLE
Repair the SQL request when upgrading

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -90,6 +90,7 @@ For this version, you should refresh your browser from the Workspace app with `C
         <pre-migration>
             <step>OCA\Workspace\Migration\ChangeGroupnamesV300</step>
             <step>OCA\Workspace\Migration\FixMigrationToV300</step>
+            <step>OCA\Workspace\Migration\ReRunChangeGroupnamesForPgSql</step>
         </pre-migration>
 	    <install>
 		    <step>OCA\Workspace\Migration\RegisterWorkspaceUsersGroup</step>

--- a/lib/Db/GroupFoldersGroupsMapper.php
+++ b/lib/Db/GroupFoldersGroupsMapper.php
@@ -60,8 +60,8 @@ class GroupFoldersGroupsMapper extends QBMapper {
 					'gf_groups.folder_id'
 				)
 			)
-			->where('group_id not like "SPACE-GE%"')
-			->andWhere('group_id not like "SPACE-U%"');
+			->where('group_id not like \'SPACE-GE%\'')
+			->andWhere('group_id not like \'SPACE-U%\'');
 
 		return $qb->executeQuery()->fetchAll();
 	}

--- a/lib/Db/GroupFoldersGroupsMapper.php
+++ b/lib/Db/GroupFoldersGroupsMapper.php
@@ -62,9 +62,9 @@ class GroupFoldersGroupsMapper extends QBMapper {
 			)
 			->where('group_id not like :managerGroup')
 			->andWhere('group_id not like :userGroup')
-            ->setParameter('managerGroup', 'SPACE-GE%')
-            ->setParameter('userGroup', 'SPACE-U%')
-        ;
+			->setParameter('managerGroup', 'SPACE-GE%')
+			->setParameter('userGroup', 'SPACE-U%')
+		;
 
 		return $qb->executeQuery()->fetchAll();
 	}

--- a/lib/Db/GroupFoldersGroupsMapper.php
+++ b/lib/Db/GroupFoldersGroupsMapper.php
@@ -60,8 +60,11 @@ class GroupFoldersGroupsMapper extends QBMapper {
 					'gf_groups.folder_id'
 				)
 			)
-			->where('group_id not like \'SPACE-GE%\'')
-			->andWhere('group_id not like \'SPACE-U%\'');
+			->where('group_id not like :managerGroup')
+			->andWhere('group_id not like :userGroup')
+            ->setParameter('managerGroup', 'SPACE-GE%')
+            ->setParameter('userGroup', 'SPACE-U%')
+        ;
 
 		return $qb->executeQuery()->fetchAll();
 	}

--- a/lib/Migration/ReRunChangeGroupnamesForPgSql.php
+++ b/lib/Migration/ReRunChangeGroupnamesForPgSql.php
@@ -2,44 +2,38 @@
 
 namespace OCA\Workspace\Migration;
 
-use OCP\IConfig;
-use OCP\Migration\IOutput;
-use OCP\Migration\IRepairStep;
 use OCA\Workspace\Upgrade\Upgrade;
 use OCA\Workspace\Upgrade\UpgradeV300;
 use OCP\AppFramework\Services\IAppConfig;
+use OCP\IConfig;
+use OCP\Migration\IOutput;
+use OCP\Migration\IRepairStep;
 
-class ReRunChangeGroupnamesForPgSql implements IRepairStep
-{
-    public function __construct(
-        private IConfig $config,
-        private IAppConfig $appConfig,
-        private UpgradeV300 $upgrade,
-    )
-    {
-    }
+class ReRunChangeGroupnamesForPgSql implements IRepairStep {
+	public function __construct(
+		private IConfig $config,
+		private IAppConfig $appConfig,
+		private UpgradeV300 $upgrade,
+	) {
+	}
 
-    public function getName(): string
-    {
-        return 'Rerun the change groupnames repair step for a Nextcloud instance using PostgreSQL.';
-    }
+	public function getName(): string {
+		return 'Rerun the change groupnames repair step for a Nextcloud instance using PostgreSQL.';
+	}
 
-    public function run(IOutput $output): void
-    {
-        $sgbdName = $this->config->getSystemValue('dbtype');
+	public function run(IOutput $output): void {
+		$sgbdName = $this->config->getSystemValue('dbtype');
 
-        if ($sgbdName !== 'pgsql')
-        {
-            return;
-        }
+		if ($sgbdName !== 'pgsql') {
+			return;
+		}
 
-        $statusMigration = boolval($this->appConfig->getAppValue(Upgrade::CONTROL_MIGRATION_V3, '1'));
+		$statusMigration = boolval($this->appConfig->getAppValue(Upgrade::CONTROL_MIGRATION_V3, '1'));
 
-        if ($statusMigration === true)
-        {
-            return;
-        }
+		if ($statusMigration === true) {
+			return;
+		}
 
-        $this->upgrade->upgrade();
-    }
+		$this->upgrade->upgrade();
+	}
 }

--- a/lib/Migration/ReRunChangeGroupnamesForPgSql.php
+++ b/lib/Migration/ReRunChangeGroupnamesForPgSql.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace OCA\Workspace\Migration;
+
+use OCP\IConfig;
+use OCP\Migration\IOutput;
+use OCP\Migration\IRepairStep;
+use OCA\Workspace\Upgrade\Upgrade;
+use OCA\Workspace\Upgrade\UpgradeV300;
+use OCP\AppFramework\Services\IAppConfig;
+
+class ReRunChangeGroupnamesForPgSql implements IRepairStep
+{
+    public function __construct(
+        private IConfig $config,
+        private IAppConfig $appConfig,
+        private UpgradeV300 $upgrade,
+    )
+    {
+    }
+
+    public function getName(): string
+    {
+        return 'Rerun the change groupnames repair step for a Nextcloud instance using PostgreSQL.';
+    }
+
+    public function run(IOutput $output): void
+    {
+        $sgbdName = $this->config->getSystemValue('dbtype');
+
+        if ($sgbdName !== 'pgsql')
+        {
+            return;
+        }
+
+        $statusMigration = boolval($this->appConfig->getAppValue(Upgrade::CONTROL_MIGRATION_V3, '1'));
+
+        if ($statusMigration === true)
+        {
+            return;
+        }
+
+        $this->upgrade->upgrade();
+    }
+}


### PR DESCRIPTION
When we upgrade the workspace app 2.0.1 to 3.0.X. We have a problem using double quotes for an expression, because the expression is interpreted as a column.