### PR TITLE
Make the distinction between the page#index

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -153,6 +153,7 @@ return [
 			'verb' => 'GET',
 			'requirements' => array('path' => '.*'),
 			'defaults' => array('path' => 'dummy'),
+			'postfix' => 'catchall',
 		]
 	]
 ];


### PR DESCRIPTION
I added the `'postfix' => 'catchall'` to make the distinction between the two page#index routes.