### PR TITLE
Don't remove an user from a subgroup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix/move v300 constant/stable3.0 ( [#845](https://github.com/arawa/workspace/pull/845) )
 - Repair the migration v3.0.0 and v3.0.1 ( [#843](https://github.com/arawa/workspace/pull/843/files) )
+- fix/delete-a-user-when-adding-him-to-another-group/901 ( [#907](https://github.com/arawa/workspace/pull/907) )
 
 # [3.0.1] - 2023-05-26
 

--- a/src/SelectUsers.vue
+++ b/src/SelectUsers.vue
@@ -162,15 +162,6 @@ export default {
 			this.allSelectedUsers.forEach(user => {
 				let gid = ''
 				if (this.$route.params.group !== undefined) {
-					if (this.$store.getters.isMember(this.$route.params.space, user)) {
-						if (user.role === 'user') {
-							this.$store.dispatch('removeUserFromGroup', {
-								name: this.$route.params.space,
-								gid: ManagerGroup.getGid(space),
-								user,
-							})
-						}
-					}
 					// Adding a user to a workspace 'subgroup
 					this.$store.dispatch('addUserToGroup', {
 						name: this.$route.params.space,


### PR DESCRIPTION
I deleted an old code which deletes an user as soon as him/her is added to another a subgroup.

Resolve this issue: https://github.com/arawa/workspace/issues/901

@dorianne-arawa we must test this fix.