### PR TITLE
Backport: Problem about renaming a space

### DIFF
--- a/lib/Controller/GroupController.php
+++ b/lib/Controller/GroupController.php
@@ -152,7 +152,12 @@ class GroupController extends Controller {
 				|| str_starts_with($group->getGID(), 'SPACE-G-');
 		});
 
-		if (!empty($groups)) {
+		$groupsNameSearched = array_map(
+			fn ($group) => $group->getGID(),
+			$groups);
+
+		if (!empty($groups)
+			&& in_array($newGroupName, $groupsNameSearched)) {
 			return new JSONResponse(
 				'This group already exists. Please, change the name',
 				Http::STATUS_CONFLICT

--- a/src/SpaceDetails.vue
+++ b/src/SpaceDetails.vue
@@ -205,16 +205,23 @@ export default {
 				})
 
 				const groupKeys = Object.keys(space.groups)
-
 				groupKeys.forEach(key => {
 					const group = space.groups[key]
+					/**
+					 * To fix a bug where the space is renamed to single
+					 * then to plural (or inversely)
+					 * This bug is present from release 3.0.2
+					 */
+					if (!this.checkSpaceNameIsEqual(group.displayName, oldSpaceName)) {
+						group.displayName = this.replaceSpaceName(group.displayName, oldSpaceName)
+					}
 					const newDisplayName = group.displayName.replace(oldSpaceName, newSpaceName)
 
 					// Renames group
 					this.$store.dispatch('renameGroup', {
-					  name: newSpaceName,
-					  gid: group.gid,
-					  newGroupName: newDisplayName,
+						name: newSpaceName,
+						gid: group.gid,
+						newGroupName: newDisplayName,
 					})
 				})
 
@@ -232,6 +239,56 @@ export default {
 				const text = t('workspace', 'Your Workspace name must not contain the following characters: [ ~ < > { } | ; . : , ! ? \' @ # $ + ( ) % \\\\ ^ = / & * ]')
 				showNotificationError('Error to rename space', text, 5000)
 			}
+		},
+		/**
+		 * @param {string} groupname the displayname from a group
+		 * @param {string} oldSpaceName the currently space name
+		 * To fix a bug from release 3.0.2
+		 */
+		checkSpaceNameIsEqual(groupname, oldSpaceName) {
+			let spaceNameFiltered = ''
+
+			if (groupname.startsWith('U-')) {
+				spaceNameFiltered = groupname.replace('U-', '')
+			}
+
+			if (groupname.startsWith('WM-')) {
+				spaceNameFiltered = groupname.replace('WM-', '')
+			} else if (groupname.startsWith('GE-')) {
+				spaceNameFiltered = groupname.replace('GE-', '')
+			}
+
+			if (groupname.startsWith('G-')) {
+				spaceNameFiltered = groupname.replace('G-', '')
+			}
+
+			if (spaceNameFiltered === oldSpaceName) {
+				return true
+			}
+
+			return false
+		},
+		/**
+		 * @param {string} groupname the displayname from a group
+		 * @param {string} oldSpaceName the currently space name
+		 * To fix a bug from release 3.0.2
+		 */
+		replaceSpaceName(groupname, oldSpaceName) {
+			const spaceNameSplitted = groupname
+				.split('-')
+				.filter(element => element)
+
+			if (spaceNameSplitted[0] === 'WM'
+					|| spaceNameSplitted[0] === 'U') {
+				spaceNameSplitted[1] = oldSpaceName
+			}
+
+			if (spaceNameSplitted[0] === 'G') {
+				const lengthMax = spaceNameSplitted.length - 1
+				spaceNameSplitted[lengthMax] = oldSpaceName
+			}
+
+			return spaceNameSplitted.join('-')
 		},
 		// Sets a space's quota
 		setSpaceQuota(quota) {


### PR DESCRIPTION
When we rename a space from plural to single (or inversely) all groups are bad renamed.

It's a backport from #893 