### PR TITLE
Backport: Add an arrow in a field

### DIFF
--- a/src/SpaceDetails.vue
+++ b/src/SpaceDetails.vue
@@ -56,6 +56,7 @@
 							ref="createGroupInput"
 							icon="icon-group"
 							:close-after-click="true"
+							:show-trailing-button="true"
 							@submit="onNewGroup">
 							{{ t('workspace', 'Group name') }}
 						</NcActionInput>


### PR DESCRIPTION
I added an arrow for the creating group field.

It's a backport from #900 