### PR TITLE
Backport: Check if an user is a space manager

### DIFF
--- a/lib/Controller/GroupController.php
+++ b/lib/Controller/GroupController.php
@@ -261,7 +261,9 @@ class GroupController extends Controller {
 				$this->logger->debug('User removed from group: ' . $NCGroup->getDisplayName());
 				if ($groupId === WorkspaceManagerGroup::get($space['id'])) {
 					$this->logger->debug('Removing user from a workspace manager group, removing it from the WorkspacesManagers group if needed.');
-					$this->userService->removeGEFromWM($NCUser, $space);
+					if ($this->userService->canRemoveWorkspaceManagers($NCUser, $space)) {
+						$this->userService->removeGEFromWM($NCUser);
+					}
 				}
 			}
 		} else {
@@ -272,7 +274,9 @@ class GroupController extends Controller {
 			if ($gid === WorkspaceManagerGroup::get($space['id'])) {
 				// Removing user from a GE- group
 				$this->logger->debug('Removing user from a workspace manager group, removing it from the WorkspacesManagers group if needed.');
-				$this->userService->removeGEFromWM($NCUser, $space);
+				if ($this->userService->canRemoveWorkspaceManagers($NCUser, $space)) {
+					$this->userService->removeGEFromWM($NCUser);
+				}
 			}
 		}
 

--- a/lib/Controller/WorkspaceController.php
+++ b/lib/Controller/WorkspaceController.php
@@ -137,7 +137,9 @@ class WorkspaceController extends Controller {
 		$this->logger->debug('Removing GE users from the WorkspacesManagers group if needed.');
 		$GEGroup = $this->groupManager->get(WorkspaceManagerGroup::get($workspace['id']));
 		foreach ($GEGroup->getUsers() as $user) {
-			$this->userService->removeGEFromWM($user, $workspace);
+			if ($this->userService->canRemoveWorkspaceManagers($user, $workspace)) {
+				$this->userService->removeGEFromWM($user);
+			}
 		}
 
 		// Removes all workspaces groups
@@ -245,7 +247,9 @@ class WorkspaceController extends Controller {
 			// Changing a user's role from admin to user
 			$GEgroup->removeUser($user);
 			$this->logger->debug('Removing a user from a GE group. Removing it from the ' . ManagersWorkspace::WORKSPACES_MANAGERS . ' group if needed.');
-			$this->userService->removeGEFromWM($user, $space);
+			if ($this->userService->canRemoveWorkspaceManagers($user, $space)) {
+				$this->userService->removeGEFromWM($user, $space);
+			}
 		} else {
 			// Changing a user's role from user to admin
 			$this->groupManager->get(WorkspaceManagerGroup::get($space['id']))->addUser($user);


### PR DESCRIPTION
I have checked incorrectly whether an user is a space manager of another space.

It's a backport from #915 