### PR TITLE
backport: Limit the search to members

### DIFF
--- a/lib/Share/Group/GroupMembersOnlyChecker.php
+++ b/lib/Share/Group/GroupMembersOnlyChecker.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace OCA\Workspace\Share\Group;
+
+use OCP\IGroupManager;
+use OCP\IUserSession;
+use OCP\Share\IManager;
+
+class GroupMembersOnlyChecker {
+	public function __construct(
+		private IGroupManager $groupManager,
+		private IManager $shareManager,
+		private IUserSession $userSession
+	) {
+	}
+
+	public function checkboxIsChecked(): bool {
+		return $this->shareManager->shareWithGroupMembersOnly();
+	}
+
+	public function groupsExcludeSelected(): bool {
+		if (
+			method_exists(
+				$this->shareManager,
+				"shareWithGroupMembersOnlyExcludeGroupsList"
+			)
+		) {
+			return $this->shareManager->shareWithGroupMembersOnly()
+				&& !empty($this->shareManager->shareWithGroupMembersOnlyExcludeGroupsList());
+		}
+
+		return false;
+	}
+
+	public function checkMemberInGroupExcluded(): bool {
+		$excludedGroups = $this->shareManager->shareWithGroupMembersOnlyExcludeGroupsList();
+
+		$userSession = $this->userSession->getUser();
+		$uid = $userSession->getUID();
+
+		foreach ($excludedGroups as $gid) {
+			if ($this->groupManager->isInGroup($uid, $gid)) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+}

--- a/lib/Share/Group/ShareMembersOnlyFilter.php
+++ b/lib/Share/Group/ShareMembersOnlyFilter.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace OCA\Workspace\Share\Group;
+
+use OCP\IGroupManager;
+use OCP\IUser;
+use OCP\IUserSession;
+use OCP\Share\IManager;
+
+class ShareMembersOnlyFilter {
+	public function __construct(
+		private IGroupManager $groupManager,
+		private IManager $shareManager,
+		private IUserSession $userSession
+	) {
+	}
+
+	/**
+	 * @param IUser[] $users
+	 * @return IUser[]
+	 * Return users with groups in common.
+	 * Except some listed in the drop-down list
+	 * (`Settings > Share > Restrict users to only share with users in their groups > Ingore the following groups when cheking group membership`).
+	 */
+	public function excludeGroupsList(array $users): array {
+		$usersNotExclude = [];
+
+		if (method_exists($this->shareManager, "shareWithGroupMembersOnlyExcludeGroupsList")) {
+			$excludedGroups = $this->shareManager->shareWithGroupMembersOnlyExcludeGroupsList();
+			$userSession = $this->userSession->getUser();
+			$groupsOfUserSession = $this->groupManager->getUserGroups($userSession);
+			$groupnamesOfUserSession = array_map(fn ($group) => $group->getGID(), $groupsOfUserSession);
+
+			if (!empty($excludedGroups)) {
+				$usersNotExclude = array_filter($users, function ($user) use ($excludedGroups, $groupnamesOfUserSession) {
+					$groups = $this->groupManager->getUserGroups($user);
+					$groupnames = array_values(array_map(fn ($group) => $group->getGID(), $groups));
+					$commonGroups = array_intersect($groupnamesOfUserSession, $groupnames);
+					return count(array_diff($commonGroups, $excludedGroups)) !== 0;
+				});
+			}
+
+			return $usersNotExclude;
+		}
+	}
+
+	/**
+	 * @param IUser[] $users
+	 *
+	 * @return IUser[]
+	 */
+	public function filterUsersGroupOnly(array $users): array {
+		$usersInTheSameGroup = [];
+		$userSession = $this->userSession->getUser();
+		$groupsOfUserSession = $this->groupManager->getUserGroups($userSession);
+
+		foreach ($groupsOfUserSession as $group) {
+			$usersInTheSameGroup = array_merge($usersInTheSameGroup, $group->getUsers());
+		}
+
+		$usersInTheSameGroup = array_filter(
+			$users,
+			function ($user) use ($usersInTheSameGroup) {
+				$usernames = array_values(array_map(fn ($user) => $user->getUID(), $usersInTheSameGroup));
+				return in_array($user->getUID(), $usernames);
+			});
+
+		return $usersInTheSameGroup;
+	}
+}


### PR DESCRIPTION
Limit the search to members of the same group except for specific groups.

I splited the code in 2 classes :

- GroupMembersOnlyChecker : To check if the checkbox for the "Allow apps to use the Share API" and check if groups are listed from the multiselect.
- ShareMembersOnlyFilter : to get the members only the same group or excepted a few groups from the multiselect.

Return users with common groups. Except users belonging to groups listed in the drop-down list (`Settings > Share > Restrict users to only share with users in their groups > Ingore the following groups when cheking group membership`).