### PR TITLE
Use default values when prefix options are missing

### DIFF
--- a/lib/Migration/FixMigrationToV300.php
+++ b/lib/Migration/FixMigrationToV300.php
@@ -3,6 +3,7 @@
 namespace OCA\Workspace\Migration;
 
 use OCA\Workspace\AppInfo\Application;
+use OCA\Workspace\Service\Group\GroupsWorkspace;
 use OCA\Workspace\Upgrade\Upgrade;
 use OCA\Workspace\Upgrade\UpgradeFixV300V301;
 use OCP\AppFramework\Services\IAppConfig as ServiceIAppConfig;
@@ -37,8 +38,8 @@ class FixMigrationToV300 implements IRepairStep {
 
 		if (!$this->appConfigManager->hasKey(Application::APP_ID, 'DISPLAY_PREFIX_MANAGER_GROUP')
 			&& !$this->appConfigManager->hasKey(Application::APP_ID, 'DISPLAY_PREFIX_USER_GROUP')) {
-			$this->appConfig->setAppValue('DISPLAY_PREFIX_MANAGER_GROUP', 'WM-');
-			$this->appConfig->setAppValue('DISPLAY_PREFIX_USER_GROUP', 'U-');
+			$this->appConfig->setAppValue('DISPLAY_PREFIX_MANAGER_GROUP', GroupsWorkspace::DEFAULT_DISPLAY_PREFIX_MANAGER_GROUP);
+			$this->appConfig->setAppValue('DISPLAY_PREFIX_USER_GROUP', GroupsWorkspace::DEFAULT_DISPLAY_PREFIX_USER_GROUP);
 		}
 
 		$this->upgrade->upgrade();

--- a/lib/Service/Group/GroupsWorkspace.php
+++ b/lib/Service/Group/GroupsWorkspace.php
@@ -31,6 +31,8 @@ abstract class GroupsWorkspace {
 	private const GID_SPACE_MANAGER = 'GE-';
 	private const GID_SPACE_USERS = 'U-';
 	private const GID_SPACE = 'SPACE-';
+	public const DEFAULT_DISPLAY_PREFIX_MANAGER_GROUP = 'WM-';
+	public const DEFAULT_DISPLAY_PREFIX_USER_GROUP = 'U-';
 
 	protected const PREFIX_GID_MANAGERS = self::GID_SPACE . self::GID_SPACE_MANAGER;
 	protected const PREFIX_GID_USERS = self::GID_SPACE . self::GID_SPACE_USERS;
@@ -39,8 +41,8 @@ abstract class GroupsWorkspace {
 	protected static string $DISPLAY_PREFIX_USER_GROUP;
 
 	public function __construct(IAppConfig $appConfig) {
-		self::$DISPLAY_PREFIX_MANAGER_GROUP = $appConfig->getAppValue('DISPLAY_PREFIX_MANAGER_GROUP');
-		self::$DISPLAY_PREFIX_USER_GROUP = $appConfig->getAppValue('DISPLAY_PREFIX_USER_GROUP');
+		self::$DISPLAY_PREFIX_MANAGER_GROUP = $appConfig->getAppValue('DISPLAY_PREFIX_MANAGER_GROUP', self::DEFAULT_DISPLAY_PREFIX_MANAGER_GROUP);
+		self::$DISPLAY_PREFIX_USER_GROUP = $appConfig->getAppValue('DISPLAY_PREFIX_USER_GROUP', self::DEFAULT_DISPLAY_PREFIX_USER_GROUP);
 	}
 
 	public static function getDisplayPrefixManagerGroup(): string {


### PR DESCRIPTION
- use default values
- use same values in migration