### PR TITLE
Release 3.2.0 and available for nc29

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### stableX.X
 
-#### Added
+## [3.2.0] - 2024-05-30
+
+### Added
 
 - Close menu on group rename error message ([#839](https://github.com/arawa/workspace/pull/839))
 - Add an arrow from the create group ([#900](https://github.com/arawa/workspace/pull/900))
 - Create occ command to import and create workspace ( [#902](https://github.com/arawa/workspace/pull/902) )
 
-#### Fixed
+### Fixed
 
 - Fix/move v300 constant/stable3.0 ( [#845](https://github.com/arawa/workspace/pull/845) )
 - Repair the migration v3.0.0 and v3.0.1 ( [#843](https://github.com/arawa/workspace/pull/843/files) )
@@ -248,7 +250,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Define users' roles (GeneralManager and WorkspacesManager)
 
 
-[Unreleased]: https://github.com/arawa/workspace/compare/v3.1.0...main
+[Unreleased]: https://github.com/arawa/workspace/compare/v3.2.0...main
+[3.2.0]: https://github.com/arawa/workspace/compare/v3.1.0...3.2.0
 [3.1.0]: https://github.com/arawa/workspace/compare/v3.0.6...3.1.0
 [3.0.6]: https://github.com/arawa/workspace/compare/v3.0.5...3.0.6
 [3.0.5]: https://github.com/arawa/workspace/compare/v3.0.4...3.0.5

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -5,7 +5,7 @@
 
     <name>Workspace</name>
 
-    <version>3.0.1</version>
+    <version>3.2.0</version>
 
     <licence>agpl</licence>
 
@@ -20,7 +20,7 @@
 
     <bugs>https://www.arawa.fr/contact/</bugs>
     <dependencies>
-        <nextcloud min-version="25" max-version="26"/>
+        <nextcloud min-version="25" max-version="29"/>
     </dependencies>
 
     <summary>Create Groupfolders with delegated management</summary>


### PR DESCRIPTION
Normally, this release should have been 4.0.0 from a dev point of view. We adapted it for marketing purposes.