### PR TITLE
[Backport] Expose our capabilities for stable3.2

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -28,12 +28,14 @@ use OCA\Workspace\Middleware\WorkspaceAccessControlMiddleware;
 use OCA\Workspace\Service\SpaceService;
 use OCA\Workspace\Service\UserService;
 use OCP\AppFramework\App;
+use OCP\AppFramework\Bootstrap\IBootContext;
+use OCP\AppFramework\Bootstrap\IBootstrap;
 use OCP\AppFramework\Bootstrap\IRegistrationContext;
 use OCP\AppFramework\Utility\IControllerMethodReflector;
 use OCP\IRequest;
 use OCP\IURLGenerator;
 
-class Application extends App {
+class Application extends App implements IBootstrap {
 	public const APP_ID = 'workspace';
 
 	public function __construct(array $urlParams = []) {
@@ -67,5 +69,12 @@ class Application extends App {
 
 		$context->registerMiddleware(WorkspaceAccessControlMiddleware::class);
 		$context->registerMiddleware(IsSpaceAdminMiddleware::class);
+		$context->registerMiddleware(IsGeneralManagerMiddleware::class);
+
+		$context->registerCapability(Capabilities::class);
+	}
+
+	public function boot(IBootContext $context): void
+	{
 	}
 }

--- a/lib/AppInfo/Capabilities.php
+++ b/lib/AppInfo/Capabilities.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\Workspace\AppInfo;
+
+use OCP\App\IAppManager;
+use OCP\Capabilities\ICapability;
+
+class Capabilities implements ICapability
+{
+    public function __construct(private IAppManager $appManager)
+    {
+    }
+
+    public function getCapabilities(): array
+    {
+        return [
+            Application::APP_ID => [
+                'version' => $this->appManager->getAppVersion(Application::APP_ID),
+                'is_enabled' => $this->appManager->isEnabledForUser(Application::APP_ID)
+            ]
+        ];
+    }
+}


### PR DESCRIPTION
We expose the app version and is enabled.

- verb: GET
- URI: /ocs/v2.php/cloud/capabilities
- Header: OCS-APIRequest:true
- Header: Accept:application/json

Respond to this need : https://github.com/arawa/workspace/issues/1040.