### PR TITLE
Check if the group already exist before rendering

### DIFF
--- a/lib/Controller/WorkspaceController.php
+++ b/lib/Controller/WorkspaceController.php
@@ -96,8 +96,8 @@ class WorkspaceController extends Controller {
 			throw new BadRequestException('spaceName must be provided');
 		}
 
-		if($this->workspaceCheck->containSpecialChar($spaceName)) {
-			throw new BadRequestException('Your Workspace name must not contain the following characters: ' . implode(" ", str_split(WorkspaceCheckService::CHARACTERS_SPECIAL)));
+		if ($this->workspaceCheck->containSpecialChar($spaceName)) {
+			throw new BadRequestException('Your Workspace name must not contain the following characters: ' . implode(' ', str_split(WorkspaceCheckService::CHARACTERS_SPECIAL)));
 		}
 		
 		if ($this->workspaceCheck->isExist($spaceName)) {
@@ -197,22 +197,22 @@ class WorkspaceController extends Controller {
 
 			$gids = array_keys($space['groups'] ?? []);
 
-            $groups = [];
+			$groups = [];
 
-            foreach ($gids as $gid) {
-                $group = $this->groupManager->get($gid);
+			foreach ($gids as $gid) {
+				$group = $this->groupManager->get($gid);
 
-                if (is_null($group)) {
-                    $this->logger->warning(
-                        "Be careful, the $gid group is not exist in the oc_groups table."
-                        . " But, it's present in the oc_group_folders_groups table."
-                        .  "It necessary to recreate it with the occ command."
-                    );
-                    continue;
-                }
+				if (is_null($group)) {
+					$this->logger->warning(
+						"Be careful, the $gid group is not exist in the oc_groups table."
+						. " But, it's present in the oc_group_folders_groups table."
+						.  'It necessary to recreate it with the occ command.'
+					);
+					continue;
+				}
 
-                $groups[] = $group;
-            }
+				$groups[] = $group;
+			}
 
 			$space['groups'] = GroupFormatter::formatGroups($groups);
 			$space['users'] = $this->workspaceService->addUsersInfo($space);
@@ -320,7 +320,7 @@ class WorkspaceController extends Controller {
 		}
 
 		if ($this->workspaceCheck->containSpecialChar($newSpaceName)) {
-			throw new BadRequestException('Your Workspace name must not contain the following characters: ' . implode(" ", str_split(WorkspaceCheckService::CHARACTERS_SPECIAL)));
+			throw new BadRequestException('Your Workspace name must not contain the following characters: ' . implode(' ', str_split(WorkspaceCheckService::CHARACTERS_SPECIAL)));
 		}
 
 		if ($newSpaceName === false ||

--- a/lib/Controller/WorkspaceController.php
+++ b/lib/Controller/WorkspaceController.php
@@ -196,8 +196,24 @@ class WorkspaceController extends Controller {
 			) : $workspace;
 
 			$gids = array_keys($space['groups'] ?? []);
-			$groups = array_map(fn ($gid) => $this->groupManager->get($gid), $gids);
-	
+
+            $groups = [];
+
+            foreach ($gids as $gid) {
+                $group = $this->groupManager->get($gid);
+
+                if (is_null($group)) {
+                    $this->logger->warning(
+                        "Be careful, the $gid group is not exist in the oc_groups table."
+                        . " But, it's present in the oc_group_folders_groups table."
+                        .  "It necessary to recreate it with the occ command."
+                    );
+                    continue;
+                }
+
+                $groups[] = $group;
+            }
+
 			$space['groups'] = GroupFormatter::formatGroups($groups);
 			$space['users'] = $this->workspaceService->addUsersInfo($space);
 	


### PR DESCRIPTION
It's possible for a group not to exist, but still to be attached to a groupfolder.
This change allows for this issue.