### PR TITLE
Disable checkbox for existing users

### DIFF
--- a/src/SelectUsers.vue
+++ b/src/SelectUsers.vue
@@ -63,6 +63,7 @@
                 class="role-toggle"
                 type="checkbox"
                 :checked="user.role === 'admin'"
+                :disabled="$store.getters.isMember($route.params.space, user)"
                 @update:checked="toggleUserRole(user)">
                 {{ t('workspace', 'S.A.') }}
               </NcCheckboxRadioSwitch>


### PR DESCRIPTION
When adding a user from a subgroup, the role checkbox should be disabled for existing user.