### PR TITLE
API for workspace deletion

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -110,7 +110,7 @@ return [
 		],
 		[
 			'name' => 'workspace#destroy',
-			'url' => '/api/delete/space',
+			'url' => '/spaces/{spaceId}',
 			'verb' => 'DELETE'
 		],
 		[

--- a/lib/Controller/WorkspaceController.php
+++ b/lib/Controller/WorkspaceController.php
@@ -142,10 +142,11 @@ class WorkspaceController extends Controller {
 	 *
 	 * @NoAdminRequired
 	 * @SpaceAdminRequired
+     * @param int $spaceId
 	 * @param array $workspace
 	 *
 	 */
-	public function destroy(array $workspace): JSONResponse {
+	public function destroy(int $spaceId, array $workspace): JSONResponse {
 		$this->logger->debug('Removing GE users from the WorkspacesManagers group if needed.');
 		$GEGroup = $this->groupManager->get(WorkspaceManagerGroup::get($workspace['id']));
 		foreach ($GEGroup->getUsers() as $user) {

--- a/src/services/groupfoldersService.js
+++ b/src/services/groupfoldersService.js
@@ -262,7 +262,8 @@ export function createGroupfolder(spaceName) {
 export function destroy(workspace) {
 	// It's possible to send data with the DELETE verb adding `data` key word as
 	// second argument in the `delete` method.
-	const result = axios.delete(generateUrl('/apps/workspace/api/delete/space'),
+  const spaceId = workspace.id
+	const result = axios.delete(generateUrl(`/apps/workspace/spaces/${spaceId}`),
 		{
 			data: {
 				workspace,

--- a/src/tests/unit/groupfoldersService.test.js
+++ b/src/tests/unit/groupfoldersService.test.js
@@ -293,7 +293,9 @@ describe('destroy', () => {
 	it('calls axios.delete method with proper parameters', async () => {
 		axios.delete.mockResolvedValue(responseValue)
 		await destroy('foobar')
-		expect(axios.delete).toHaveBeenCalledWith('/apps/workspace/api/delete/space', {
+		const spaceId = workspace.id
+		
+		expect(axios.delete).toHaveBeenCalledWith(`/apps/workspace/space/${spaceId}`, {
 			data: { workspace: 'foobar' },
 		})
 	})


### PR DESCRIPTION
We have implemented the IBootstrap interface in the Application class. This means that Middleware is registered differently, and the destroy() method in the WorkspaceController could not work without this change.