### PR TITLE
Find all added groups instead of just one

### DIFF
--- a/lib/Db/GroupFoldersGroupsMapper.php
+++ b/lib/Db/GroupFoldersGroupsMapper.php
@@ -93,7 +93,7 @@ class GroupFoldersGroupsMapper extends QBMapper {
 		return $this->findEntities($query);
 	}
 
-	public function findAddedGroup($groupfolderId) : ConnectedGroup|false {
+	public function findAddedGroups($groupfolderId) : array|false {
 		$qb = $this->db->getQueryBuilder();
 		$query = $qb
 			->select([ 'space_id', 'group_id as gid' ])
@@ -122,7 +122,7 @@ class GroupFoldersGroupsMapper extends QBMapper {
 			return false;
 		}
 
-		return $this->findEntity($query);
+		return $this->findEntities($query);
 	}
 
 	public function isUserConnectedGroup(string $uid, string $gid): mixed {

--- a/lib/Service/Group/ConnectedGroupsService.php
+++ b/lib/Service/Group/ConnectedGroupsService.php
@@ -160,15 +160,21 @@ class ConnectedGroupsService {
 
 	public function isUserConnectedGroup(string $uid, int $groupfolderId): bool {
 
-		$connectedGroup = $this->mapper->findAddedGroup($groupfolderId);
+		$connectedGroups = $this->mapper->findAddedGroups($groupfolderId);
 
-		if ($connectedGroup === false) {
+		if ($connectedGroups === false) {
 			return false;
 		}
 		
-		$group = $this->groupManager->get($connectedGroup->getGid());
 		$user = $this->userManager->get($uid);
+		$groups = array_map(fn ($group) => $this->groupManager->get($group->getGid()), $connectedGroups);
+
+		foreach($groups as $group) {
+			if ($group->inGroup($user)) {
+				return true;
+			}
+		}
 		
-		return $group->inGroup($user);
+		return false;
 	}
 }


### PR DESCRIPTION
This fix resolves an issue with displaying workspaces, which could trigger an error notification. A user can belong to multiple groups, and this change ensures that all groups are considered.

Special thank to @smarinier :pray: 