### PR TITLE
Check if a user belongs to a connected group

### DIFF
--- a/lib/Controller/ConnectedGroupController.php
+++ b/lib/Controller/ConnectedGroupController.php
@@ -93,7 +93,7 @@ class ConnectedGroupController extends Controller {
 		};
 
 		foreach ($users as &$user) {
-			if (array_key_exists('groups', $user)) {
+			if (array_key_exists('groups', $user) && $user['is_connected'] === true) {
 				array_push($user['groups'], 'SPACE-U-' . $space->getSpaceId());
 			}
 		}

--- a/lib/Service/User/UserFormatter.php
+++ b/lib/Service/User/UserFormatter.php
@@ -28,12 +28,14 @@ use OCA\Workspace\Roles;
 use OCA\Workspace\Service\Group\ConnectedGroupsService;
 use OCA\Workspace\Service\Group\GroupsWorkspaceService;
 use OCA\Workspace\Service\Group\UserGroup;
+use OCP\IGroupManager;
 use OCP\IURLGenerator;
 use OCP\IUser;
 
 class UserFormatter {
 	public function __construct(
 		private GroupsWorkspaceService $groupsWorkspace,
+		private IGroupManager $groupManager,
 		private ConnectedGroupsService $connectedGroupsService,
 		private IURLGenerator $urlGenerator,
 		private UserGroup $userGroup,
@@ -46,8 +48,6 @@ class UserFormatter {
 	public function formatUsers(array $users, array $groupfolder, string $spaceId): array {
 		$groupWorkspaceManager = $this->groupsWorkspace->getWorkspaceManagerGroup($spaceId);
 
-		$userGroup = $this->userGroup->get($spaceId);
-
 		$usersFormatted = [];
 		foreach ($users as $user) {
 			if ($groupWorkspaceManager->inGroup($user)) {
@@ -56,13 +56,15 @@ class UserFormatter {
 				$role = Roles::User;
 			}
 
+			$isConnected = $this->connectedGroupsService->isUserConnectedGroup($user->getUID(), $groupfolder);
+
 			$usersFormatted[$user->getUID()] = [
 				'uid' => $user->getUID(),
 				'name' => $user->getDisplayName(),
 				'email' => $user->getEmailAddress(),
 				'subtitle' => $user->getEmailAddress(),
 				'groups' => $this->groupsWorkspace->getGroupsUserFromGroupfolder($user, $groupfolder, $spaceId),
-				'is_connected' => $this->connectedGroupsService->isUserConnectedGroup($user->getUID(), $groupfolder['id']),
+				'is_connected' => $isConnected,
 				'profile' => $this->urlGenerator->linkToRouteAbsolute('core.ProfilePage.index', ['targetUserId' => $user->getUID()]),
 				'role' => $role
 			];

--- a/lib/Service/UserService.php
+++ b/lib/Service/UserService.php
@@ -25,6 +25,7 @@
 
 namespace OCA\Workspace\Service;
 
+use OCA\Workspace\Db\GroupFoldersGroupsMapper;
 use OCA\Workspace\Service\Group\ConnectedGroupsService;
 use OCA\Workspace\Service\Group\ManagersWorkspace;
 use OCA\Workspace\Service\Group\UserGroup;
@@ -43,6 +44,7 @@ class UserService {
 		private ConnectedGroupsService $connectedGroups,
 		private IURLGenerator $urlGenerator,
 		private UserGroup $userGroup,
+		private GroupFoldersGroupsMapper $groupFoldersGroupsMapper,
 	) {
 	}
 
@@ -84,8 +86,8 @@ class UserService {
 			}
 		}
 
-		$userGroup = $this->userGroup->get($space['id']);
-		
+		$isConnected = $this->connectedGroups->isUserConnectedGroup($user->getUID(), $space);
+
 		return [
 			'uid' => $user->getUID(),
 			'name' => $user->getDisplayName(),
@@ -93,7 +95,7 @@ class UserService {
 			'subtitle' => $user->getEmailAddress(),
 			'groups' => $groups,
 			'role' => $role,
-			'is_connected' => $this->connectedGroups->isUserConnectedGroup($user->getUID(), $space['groupfolder_id'] ?? $space['groupfolderId']),
+			'is_connected' => $isConnected,
 			'profile' => $this->urlGenerator->linkToRouteAbsolute('core.ProfilePage.index', ['targetUserId' => $user->getUID()])
 		];
 	}

--- a/lib/Users/UserFormatter.php
+++ b/lib/Users/UserFormatter.php
@@ -34,16 +34,13 @@ class UserFormatter {
 			}
 		}
 
-		$userGroup = $this->userGroup->get($space['id']);
-
-		// var_dump($space);
 		return [
 			'uid' => $user->getUID(),
 			'name' => $user->getDisplayName(),
 			'email' => $user->getEmailAddress(),
 			'subtitle' => $user->getEmailAddress(),
 			'groups' => $groups,
-			'is_connected' => $this->connectedGroupsService->isUserConnectedGroup($user->getUID(), $space['groupfolder_id']),
+			'is_connected' => $this->connectedGroupsService->isUserConnectedGroup($user->getUID(), $space),
 			'profile' => $this->urlGenerator->linkToRouteAbsolute('core.ProfilePage.index', ['targetUserId' => $user->getUID()]),
 			'role' => $role
 		];


### PR DESCRIPTION
In this fix/refactor, I determine if a user is part of a connected group by following these steps:

1. Check if the user is in the connected group.
2. Check if the user is hard registered in the user group (SPACE-U).

The `isUserConnectedGroup` function returns true if the user is in a connected group, and false otherwise.

In the `addGroup` function, I check if the current user is in a connected group. If not, the user is not added to the group.

OP#3548 