### PR TITLE
Hide disabled users from connected groups

### DIFF
--- a/lib/Group/GroupBackend.php
+++ b/lib/Group/GroupBackend.php
@@ -77,9 +77,9 @@ class GroupBackend extends ABackend implements GroupInterface, INamedBackend, IC
 		$this->avoidRecurse_groups = true;
 		$user = $this->userManager->get($uid);
 
-        if (!$user->isEnabled()) {
-            return [];
-        }
+		if (!$user->isEnabled()) {
+			return [];
+		}
 
 		if ($user) {
 			$groupIds = $this->groupManager->getUserGroupIds($user);
@@ -149,9 +149,9 @@ class GroupBackend extends ABackend implements GroupInterface, INamedBackend, IC
 		foreach ($groups as $group) {
 			if (!is_null($group)) {
 				foreach ($group->getUsers() as $user) {
-                    if ($user->isEnabled()) {
-                        $users[] = $user->getUID();
-                    }
+					if ($user->isEnabled()) {
+						$users[] = $user->getUID();
+					}
 				};
 			}
 		}

--- a/lib/Group/GroupBackend.php
+++ b/lib/Group/GroupBackend.php
@@ -76,6 +76,11 @@ class GroupBackend extends ABackend implements GroupInterface, INamedBackend, IC
 		$avoid = $this->avoidRecurse_groups;
 		$this->avoidRecurse_groups = true;
 		$user = $this->userManager->get($uid);
+
+        if (!$user->isEnabled()) {
+            return [];
+        }
+
 		if ($user) {
 			$groupIds = $this->groupManager->getUserGroupIds($user);
 		} else {
@@ -144,7 +149,9 @@ class GroupBackend extends ABackend implements GroupInterface, INamedBackend, IC
 		foreach ($groups as $group) {
 			if (!is_null($group)) {
 				foreach ($group->getUsers() as $user) {
-					$users[] = $user->getUID();
+                    if ($user->isEnabled()) {
+                        $users[] = $user->getUID();
+                    }
 				};
 			}
 		}

--- a/lib/Service/Group/GroupFormatter.php
+++ b/lib/Service/Group/GroupFormatter.php
@@ -48,8 +48,8 @@ class GroupFormatter {
 				$backendnames
 			);
 
-            $users = $group->getUsers();
-            $users = array_filter($users, fn($user) => $user->isEnabled());
+			$users = $group->getUsers();
+			$users = array_filter($users, fn ($user) => $user->isEnabled());
 
 			$groupsFormat[$group->getGID()] = [
 				'gid' => $group->getGID(),

--- a/lib/Service/Group/GroupFormatter.php
+++ b/lib/Service/Group/GroupFormatter.php
@@ -48,11 +48,14 @@ class GroupFormatter {
 				$backendnames
 			);
 
+            $users = $group->getUsers();
+            $users = array_filter($users, fn($user) => $user->isEnabled());
+
 			$groupsFormat[$group->getGID()] = [
 				'gid' => $group->getGID(),
 				'displayName' => $group->getDisplayName(),
 				'types' => $group->getBackendNames(),
-				'usersCount' => $group->count(),
+				'usersCount' => count($users),
 				'slug' => Slugger::slugger($group->getGID())
 			];
 		}

--- a/tests/Unit/Space/SpaceManagerTest.php
+++ b/tests/Unit/Space/SpaceManagerTest.php
@@ -195,22 +195,11 @@ class SpaceManagerTest extends TestCase {
 			->willReturn('WM-Espace01')
 		;
 
-		$workspaceManagerGroupMock
-			->expects($this->once())
-			->method('count')
-			->willReturn(0)
-		;
-
 		$userGroupMock = $this->createMock(IGroup::class);
 		$userGroupMock
 			->expects($this->any())
 			->method('getGID')
 			->willReturn('SPACE-U-1')
-		;
-		$userGroupMock
-			->expects($this->once())
-			->method('count')
-			->willReturn(0)
 		;
 
 		$userGroupMock


### PR DESCRIPTION
If a connected group contains disabled users, we have to hide them.

### Describe

![image](https://github.com/user-attachments/assets/c22777ec-c046-40a0-883c-661b985d64e2)

Here we have 18 users...

![image](https://github.com/user-attachments/assets/c482abba-e7b8-425d-99be-ac059134dd43)

With 2 disabled users.

![image](https://github.com/user-attachments/assets/57ad95e5-7b3a-4767-b3c6-ac7ca09ce938)

And they don't count towards the workspace.


I will backport this PR for the milestone v4.0.1.

OP#3549