### PR TITLE
fix: better handle some load errors

### DIFF
--- a/lib/Controller/WorkspaceController.php
+++ b/lib/Controller/WorkspaceController.php
@@ -238,6 +238,15 @@ class WorkspaceController extends Controller {
 
 		$groupfolder = $this->folderHelper->getFolder($space->getGroupfolderId(), $this->rootFolder->getRootFolderStorageId());
 		
+		if ($groupfolder === false) {
+			return new JSONResponse(
+				[
+					'message' => 'Failed loading groupfolder '.$space->getGroupfolderId(),
+					'success' => false
+				],
+				Http::STATUS_BAD_REQUEST);
+		}
+
 		$workspace = array_merge($groupfolder, $space->jsonSerialize());
 		$users = $this->workspaceService->addUsersInfo($workspace);
 

--- a/src/services/spaceService.js
+++ b/src/services/spaceService.js
@@ -30,7 +30,6 @@ import AddGroupToGroupfolderError from '../Errors/Groupfolders/AddGroupToGroupfo
 
 /**
 	* @param {string} spaceName it's a name for the space to create
-	* @param {number} folderId it's the id of groupfolder
 	* @param {object} vueInstance it's an instance of vue
 	* @return {object}
 	*/
@@ -60,7 +59,8 @@ export function createSpace(spaceName, vueInstance = undefined) {
 
 /**
  *
- * @param spaceId
+ * @param {number} spaceId id of space
+ * @return {object}
  */
 export function getUsers(spaceId) {
 	const result = axios.get(generateUrl(`/apps/workspace/spaces/${spaceId}/users`))
@@ -69,6 +69,12 @@ export function getUsers(spaceId) {
 		})
 		.catch(error => {
 			console.error('Impossible to get users from a workspace.', error)
+			let errorMessage = t('workspace', "Can't load workspace users")
+			if (error.response && error.response.data && error.response.data.message) {
+				console.error(error.response.data.message)
+				errorMessage += ': ' + error.response.data.message
+			}
+			throw new Error(errorMessage)
 		})
 	return result
 }
@@ -144,7 +150,7 @@ export function addGroupToWorkspace(spaceId, gid) {
 }
 
 /**
- * @param {integer} spaceId it's the id relative to workspace
+ * @param {number} spaceId it's the id relative to workspace
  * @return {Promise}
  */
 export function removeWorkspace(spaceId) {
@@ -161,8 +167,9 @@ export function removeWorkspace(spaceId) {
 
 /**
  *
- * @param spaceId
- * @param newSpaceName
+ * @param {number} spaceId if of space
+ * @param {string} newSpaceName new space name
+ * @return {object}
  */
 export function renameSpace(spaceId, newSpaceName) {
 	const respFormat = {

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -493,6 +493,9 @@ export default {
 			.catch(error => {
 				console.error('Impossible to get users for the workspace.')
 				console.error(error)
+				showNotificationError(t('workspace', "Can't load workspace users"))
+				context.commit('SET_LOADING_USERS_WAITTING', ({ activated: false }))
+				context.commit('SET_NO_USERS', ({ activated: true }))
 			})
 	},
 }


### PR DESCRIPTION
When loading users fails, it's locked in loading state and the workspace user is not informed (fix it)