### PR TITLE
Listing connected groups

### DIFF
--- a/lib/Service/Group/ConnectedGroupsService.php
+++ b/lib/Service/Group/ConnectedGroupsService.php
@@ -176,7 +176,7 @@ class ConnectedGroupsService {
 		}
 		
 		$user = $this->userManager->get($uid);
-		$groups = array_map(fn ($group) => $this->groupManager->get($group->getGID()), $connectedGroups);
+		$groups = array_map(fn ($group) => $this->groupManager->get($group->getGid()), $connectedGroups);
 
 		foreach ($groups as $group) {
 			if ($group->inGroup($user)) {


### PR DESCRIPTION
There is a confusion between `$group->getGID()` and the `$group->getGid()`. The `getGid()` method is used to retrieve the `gid` property from the Connected Group entity, while the `getGID()` method is from the IGroup class.