### PR TITLE
Backport: Remove duplicate users request

### DIFF
--- a/src/SpaceTable.vue
+++ b/src/SpaceTable.vue
@@ -115,9 +115,6 @@ export default {
 			this.$router.push({
 				path: `/workspace/${name}`,
 			})
-
-			const space = this.$store.state.spaces[this.$route.params.space]
-			this.$store.dispatch('loadUsers', { space })
 		},
 		initAdmins(id, name) {
 			const space = this.$store.getters.getSpaceById(id)


### PR DESCRIPTION
I removed a duplicate users request when navigating to a workspace or loading it. This improves performance when displaying users.

OP#3727