### PR TITLE
Add upper case letters to the words ‘Workspaces’ in the French translation

### DIFF
--- a/l10n/fr.js
+++ b/l10n/fr.js
@@ -6,7 +6,7 @@ OC.L10N.register(
 		'Add': 'Ajouter',
 		'Add users': 'Ajouter un utilisateur',
 		'Add a group': 'Ajouter un groupe',
-		'All spaces': 'Tous les workspaces',
+		'All spaces': 'Tous les Workspaces',
 		'Administrators': 'Workspaces Managers',
 		'wm': 'Workspace Manager',
 		'WM': 'WM',

--- a/l10n/fr.json
+++ b/l10n/fr.json
@@ -4,7 +4,7 @@
 	"Add": "Ajouter",
 	"Add users": "Ajouter des utilisateurs",
 	"Add a group": "Ajouter un groupe",
-	"All spaces": "Tous les worspaces",
+	"All spaces": "Tous les Worspaces",
 	"Administrators" : "General Managers",
 	"admin" : "Workspaces Manager",
 	"Cancel": "Annuler",


### PR DESCRIPTION
Tous les workspaces -> Tous les Workspaces