### PR TITLE
Count bubble workspace

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -113,6 +113,11 @@ return [
 			'verb' => 'DELETE'
 		],
 		[
+			'name' => 'workspace#countWorkspaces',
+			'url' => '/spaces/count',
+			'verb' => 'GET',
+		],
+		[
 			'name' => 'workspace#renameSpace',
 			'url' => '/spaces/{spaceId}',
 			'verb' => 'PATCH'

--- a/l10n/en.js
+++ b/l10n/en.js
@@ -71,6 +71,7 @@ OC.L10N.register(
 		'The %s email address is duplicated in your instance. Impossible to know which users choice or maybe is an error.': 'The %s email address is duplicated in your instance. Impossible to know which users choice or maybe is an error.',
 		'Add users': 'Add users',
 		'WM': 'WM',
+		'Workspace counting error': 'Workspace counting error',
 		'Set quota': 'Set quota',
 		'Space administrators': 'Workspace manager',
 		'Users': 'Users',

--- a/l10n/fr.js
+++ b/l10n/fr.js
@@ -22,6 +22,7 @@ OC.L10N.register(
 		'Error in file format': 'Erreur dans le format de fichier',
 		'Error in the table header': 'Erreur dans l\'en-tête',
 		'Caution, users highlighted in red are not yet member of this workspace. They will be automaticaly added.': "Attention, les utilisateurs surlignés en rouge ne sont pas encore membres du workspace. Ils seront ajoutés automatiquement à ce dernier.",
+		'Workspace counting error': 'Erreur dans le comptage des workspaces',
 		'Email address doesn\'t unique': 'L\'adresse email n\'est pas unique',
 		'The %s email address is duplicated in your instance. Impossible to know which users choice or maybe is an error.': 'L\'adresse email %s est dupliquée dans votre instance. Impossible de savoir quels utilisateurs choisir ou peut-être qu\'il y a une erreur.',
 		'or': 'ou',

--- a/l10n/fr.json
+++ b/l10n/fr.json
@@ -16,6 +16,7 @@
 	"Unknown error": "Erreur inconnue",
 	"Delete user" : "Retirer du Workspace",
 	"Group name": "Nom du groupe",
+	"Workspace counting error": "Erreur dans le comptage des workspaces",
 	"Remove added group": "Retirer le groupe ajouté",
 	"Please, note that once {groupname} group has been removed, its users will lose access to the {spacename} workspace": "Attention, après le retrait du groupe {groupname}, ses utilisateurs perdront l'accès au Workspace {spacename}",
 	"Please note that after deleting the {groupname} group, its users will retain access to the {spacename} workspace": "Attention, après la suppression du groupe {groupname}, ses utilisateurs conserveront l'accès au Workspace {spacename}",

--- a/lib/Controller/WorkspaceController.php
+++ b/lib/Controller/WorkspaceController.php
@@ -224,6 +224,17 @@ class WorkspaceController extends Controller {
 		return new JSONResponse($spaces);
 	}
 
+    /**
+     * @NoAdminRequired
+     */
+    public function countWorkspaces(): JSONResponse {
+        $count = $this->spaceMapper->countSpaces();
+
+        return new JSONResponse([
+            'count' => $count
+        ]);
+    }
+
 	/**
 	 * @NoAdminRequired
 	 */

--- a/lib/Db/SpaceMapper.php
+++ b/lib/Db/SpaceMapper.php
@@ -61,6 +61,23 @@ class SpaceMapper extends QBMapper {
 		return $this->findEntities($qb);
 	}
 
+	public function countSpaces(): int
+	{
+		$qb = $this->db->getQueryBuilder();
+
+		$qb
+			->selectAlias($qb->createFunction('COUNT(*)'), 'count')
+			->from($this->getTableName())
+		;
+
+		$res = $qb
+			->executeQuery()
+			->fetch()
+		;
+
+		return (int)$res['count'];
+	}
+
 	/**
 	 * @deprecated
 	 * @see WorkspaceController->destroy().

--- a/src/LeftSidebar.vue
+++ b/src/LeftSidebar.vue
@@ -28,7 +28,11 @@
 		<NcAppNavigationItem
 			:name="t('workspace', 'All spaces')"
 			:to="{path: '/'}"
-			:class="$route.path === '/' ? 'space-selected' : 'all-spaces'" />
+			:class="$route.path === '/' ? 'space-selected' : 'all-spaces'" >
+			<NcCounterBubble slot="counter">
+				{{ $store.state.countWorkspaces }}
+			</NcCounterBubble>
+		</NcAppNavigationItem>
 		<template #list>
 			<SpaceMenuItem
 				v-for="(space, spaceName) in $store.state.spaces"
@@ -56,12 +60,13 @@
 </template>
 
 <script>
-import { createSpace } from './services/spaceService.js'
+import { createSpace, countWorkspaces } from './services/spaceService.js'
 import { PATTERN_CHECK_NOTHING_SPECIAL_CHARACTER } from './constants.js'
 import BadCreateError from './Errors/BadCreateError.js'
 import NcAppNavigation from '@nextcloud/vue/dist/Components/NcAppNavigation.js'
 import NcAppNavigationItem from '@nextcloud/vue/dist/Components/NcAppNavigationItem.js'
 import NcAppNavigationNewItem from '@nextcloud/vue/dist/Components/NcAppNavigationNewItem.js'
+import NcCounterBubble from '@nextcloud/vue/dist/Components/NcCounterBubble.js'
 import showNotificationError from './services/Notifications/NotificationError.js'
 import SpaceMenuItem from './SpaceMenuItem.vue'
 
@@ -71,7 +76,17 @@ export default {
 		NcAppNavigation,
 		NcAppNavigationNewItem,
 		NcAppNavigationItem,
+		NcCounterBubble,
 		SpaceMenuItem,
+	},
+	data() {
+		return {
+			countWorkspaces: 0,
+		}
+	},
+	async beforeCreate() {
+		const count = await countWorkspaces()
+		this.$store.dispatch('setCountWorkspaces', { count: count.count })
 	},
 	methods: {
 		// Creates a new space and navigates to its details page
@@ -105,6 +120,7 @@ export default {
 				userCount: workspace.userCount,
 				managers: null,
 			})
+			this.$store.dispatch('incrementCountWorkspaces')
 			this.$router.push({
 				path: `/workspace/${name}`,
 			})

--- a/src/SpaceDetails.vue
+++ b/src/SpaceDetails.vue
@@ -189,6 +189,7 @@ export default {
 						})
 					}
 				})
+			this.$store.dispatch('decrementCountWorkspaces')
 		},
 		onNewGroup(e) {
 			// Hides ActionInput

--- a/src/services/spaceService.js
+++ b/src/services/spaceService.js
@@ -209,3 +209,17 @@ export function renameSpace(spaceId, newSpaceName) {
 
 	return respFormatFinal
 }
+
+/**
+ * @return Promise
+ */
+export function countWorkspaces() {
+	return axios.get(generateUrl('/apps/workspace/spaces/count'))
+		.then(resp => {
+			return resp.data
+		})
+		.catch(error => {
+			showNotificationError('Workspace counting error', error.response.data.message, 5000)
+			console.error('Workspace counting error', error)
+		})
+}

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -91,6 +91,15 @@ export default {
 	substractionGroupUserCount(context, { spaceName, gid, usersCount }) {
 		context.commit('SUBSTRACTION_GROUP_USER_COUNT', { spaceName, gid, usersCount })
 	},
+	setCountWorkspaces(context, { count }) {
+		context.commit('SET_COUNT_WORKSPACES', { count })
+	},
+	incrementCountWorkspaces(context) {
+		context.commit('INCREMENT_COUNT_WORKSPACES')
+	},
+	decrementCountWorkspaces(context) {
+		context.commit('DECREMENT_COUNT_WORKSPACES')
+	},
 	// Creates a group and navigates to its details page
 	createGroup(context, { name, gid }) {
 		// Groups must be postfixed with the ID of the space they belong

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -37,6 +37,7 @@ const store = new Store({
 		loadingUsersWaitting: false,
 		spaces: {},
 		groupfolders: {},
+		countWorkspaces: 0,
 	},
 	mutations,
 	actions,

--- a/src/store/mutations.js
+++ b/src/store/mutations.js
@@ -127,6 +127,18 @@ export default {
 		space.userCount++
 		VueSet(state.spaces, spaceName, space)
 	},
+	SET_COUNT_WORKSPACES(state, { count }) {
+		state.countWorkspaces = count
+	},
+	INCREMENT_COUNT_WORKSPACES(state) {
+		state.countWorkspaces++
+	},
+	DECREMENT_COUNT_WORKSPACES(state) {
+		if (state.countWorkspaces === 0) {
+			return
+		}
+		state.countWorkspaces--
+	},
 	DECREMENT_GROUP_USER_COUNT(state, { spaceName, gid }) {
 		const space = state.spaces[spaceName]
 		space.groups[gid].usersCount--


### PR DESCRIPTION
Create a counter bubble to display the number of workspaces on the home page, incrementing when a workspace is created and decrementing when one is removed.

[Capture vidéo du 2025-03-21 20-07-24.webm](https://github.com/user-attachments/assets/fa0707d2-a9f7-4f57-ba90-7e9b541b02a2)
