### PR TITLE
Backport: connected groups with slashs

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -94,7 +94,7 @@ return [
 		],
 		[
 			'name' => 'connectedGroup#addGroup',
-			'url' => '/spaces/{spaceId}/connected-groups/{gid}',
+			'url' => '/spaces/{spaceId}/connected-groups',
 			'verb' => 'POST',
 		],
 		[

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -358,7 +358,9 @@ export default {
 	},
 	addConnectedGroupToWorkspace(context, { spaceId, group, name }) {
 		const space = context.state.spaces[name]
-		const result = axios.post(generateUrl(`/apps/workspace/spaces/${spaceId}/connected-groups/${group.gid}`))
+		const result = axios.post(generateUrl(`/apps/workspace/spaces/${spaceId}/connected-groups`), {
+			gid: group.gid,
+		})
 			.then(resp => {
 				context.commit('addConnectedGroupToWorkspace', { name, group, slug: resp.data.slug })
 				const users = resp.data.users


### PR DESCRIPTION
Move the gid argument from the URL API to data when sending a POST request.

OP#3760