### PR TITLE
Ignore inconsistencies in the groups and subgroups listing for a workspace

### DIFF
--- a/lib/Group/Admin/AdminUserGroup.php
+++ b/lib/Group/Admin/AdminUserGroup.php
@@ -57,6 +57,8 @@ class AdminUserGroup {
 	public function removeUser(IUser $user): void {
 		$this->logger->debug('The ' . $user->getUID() . 'User is not manager of any other workspace, removing it from the ' . self::GID . ' group.');
 		$workspaceUserGroup = $this->groupManager->get(self::GID);
-		$workspaceUserGroup->removeUser($user);
+		if ($workspaceUserGroup !== null) {
+			$workspaceUserGroup->removeUser($user);
+		}
 	}
 }

--- a/lib/Group/User/UserGroup.php
+++ b/lib/Group/User/UserGroup.php
@@ -41,6 +41,9 @@ class UserGroup {
 
 	public function addUser(IUser $user, string $gid): bool {
 		$group = $this->userGroupManager->get($gid);
+		if ($group === null) {
+			return false;
+		}
 		$group->addUser($user);
 
 		return true;
@@ -48,6 +51,9 @@ class UserGroup {
 
 	public function count(int $spaceId): int {
 		$usersGroup = $this->groupManager->get($this::GID_PREFIX . $spaceId);
+		if ($usersGroup === null) {
+			return 0;
+		}
 		return $usersGroup->count();
 	}
 }

--- a/lib/Service/Group/ConnectedGroupsService.php
+++ b/lib/Service/Group/ConnectedGroupsService.php
@@ -117,7 +117,7 @@ class ConnectedGroupsService {
 		$groups = [];
 		foreach ($linkedSpaceGroups[$spaceGid] as $gid) {
 			$group = $this->groupManager->get($gid);
-			if (!UserGroup::isWorkspaceGroup($group)) {
+			if (($group !== null) && !UserGroup::isWorkspaceGroup($group)) {
 				$groups[] = $group;
 			}
 		}

--- a/lib/Service/User/UserWorkspace.php
+++ b/lib/Service/User/UserWorkspace.php
@@ -19,7 +19,10 @@ class UserWorkspace {
 		$users = [];
 
 		foreach ($groupsName as $groupName) {
-			$users[] = $this->groupManager->get($groupName)->getUsers();
+			$o_group = $this->groupManager->get($groupName);
+			if ($o_group !== null) {
+				$users[] = $o_group->getUsers();
+			}
 		}
 
 		$usersMerged = array_merge([], ...$users);

--- a/lib/Service/UserService.php
+++ b/lib/Service/UserService.php
@@ -182,7 +182,9 @@ class UserService {
 	public function removeGEFromWM(IUser $user): void {
 		$this->logger->debug('User is not manager of any other workspace, removing it from the ' . ManagersWorkspace::WORKSPACES_MANAGERS . ' group.');
 		$workspaceUserGroup = $this->groupManager->get(ManagersWorkspace::WORKSPACES_MANAGERS);
-		$workspaceUserGroup->removeUser($user);
+		if ($workspaceUserGroup !== null) {
+			$workspaceUserGroup->removeUser($user);
+		}
 
 		return;
 	}

--- a/lib/Space/SpaceManager.php
+++ b/lib/Space/SpaceManager.php
@@ -227,11 +227,12 @@ class SpaceManager {
 			}
 		}
 
-		$groups = [];
 		$this->logger->debug('Removing workspace groups.');
 		foreach (array_keys($space['groups']) as $group) {
-			$groups[] = $group;
-			$this->groupManager->get($group)->delete();
+			$o_group = $this->groupManager->get($group);
+			if ($o_group !== null) {
+				$o_group->delete();
+			}
 		}
 
 		$folderId = $space['groupfolder_id'];


### PR DESCRIPTION
if a groupfolder_group was deleted, especially as "connected group", then it crashes /spaces/