### PR TITLE
Update minimum Nextcloud version and PHP min/max versions

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -20,6 +20,7 @@
 
     <bugs>https://www.arawa.fr/contact/</bugs>
     <dependencies>
+        <php min-version="8.1" max-version="8.3" />
         <nextcloud min-version="30" max-version="30"/>
     </dependencies>
 

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -20,7 +20,7 @@
 
     <bugs>https://www.arawa.fr/contact/</bugs>
     <dependencies>
-        <nextcloud min-version="25" max-version="30"/>
+        <nextcloud min-version="30" max-version="30"/>
     </dependencies>
 
     <summary>Create Groupfolders with delegated management</summary>

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "php": ">=7.4 <=8.3"
+        "php": ">=8.1 <=8.3"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",


### PR DESCRIPTION
Please, to refer this documentation for more details: https://docs.nextcloud.com/server/latest/developer_manual/app_publishing_maintenance/app_upgrade_guide/upgrade_to_30.html#support-for-php-8-0-removed .