### PR TITLE
Redesign after updating nextcloud/vue 8.x

### DIFF
--- a/css/workspace-style.css
+++ b/css/workspace-style.css
@@ -92,6 +92,13 @@ tbody > .workspace-tr:hover {
 	margin-right: 30px;
 }
 
+/* hooks nc31 */
+.app-workspace .app-navigation__list {
+	flex-grow: 1;
+	flex-shrink: 1;
+	flex-basis: 0;
+}
+
 /* force toggle visibility */
 .workspace-sidebar .icon-collapse {
 	visibility: visible !important;

--- a/css/workspace-style.css
+++ b/css/workspace-style.css
@@ -137,8 +137,6 @@ body .icon-added-group, body .icon-added-group-dark {
 
 .icon-added-group, .icon-added-group-dark {
 	background-image: url('../img/added_group_black.svg');
-	min-width: 42px;
-	min-height: 42px;
 }
 
 .space-color-picker {

--- a/src/AddUsersTabs.vue
+++ b/src/AddUsersTabs.vue
@@ -21,17 +21,18 @@
 
 <template>
 	<div class="select-users-wrapper">
-		<NcAppSidebar name="Ajouter des utilisateurs"
+		<NcAppSidebar
 			class="my-sidebar"
-			:title="title"
-			@update:active="toggleImportTab"
-			@close="closeSidebar">
+			@update:active="toggleImportTab">
 			<NcAppSidebarTab id="search"
 				:name="titleSearch"
 				:order="1">
 				<MultiSelectUsers class="input-select-users"
 					:all-selected-users="allSelectedUsers"
 					@change="addUserToBatch" />
+				<template #icon>
+					<span />
+				</template>
 			</NcAppSidebarTab>
 			<NcAppSidebarTab id="import"
 				:name="titleImport"
@@ -42,23 +43,25 @@
 					<ButtonUploadShareFiles :all-selected-users="allSelectedUsers"
 						@push="pushUsersFromButton" />
 				</div>
+				<template #icon>
+					<div class="information-import">
+						<NcPopover>
+							<template #trigger>
+								<InformationOutline class="information-image"
+									:class="onImportTab"
+									:size="17" />
+							</template>
+							<div class="popover">
+								<p>{{ informCsvStructureMessage }}</p>
+								<br>
+								<NcRichText :use-markdown="true"
+									:text="csvTemplateMarkdown" />
+							</div>
+						</NcPopover>
+					</div>
+				</template>
 			</NcAppSidebarTab>
 		</NcAppSidebar>
-		<div class="information-import">
-			<NcPopover>
-				<template #trigger>
-					<InformationOutline class="information-image"
-						:class="onImportTab"
-						:size="17" />
-				</template>
-				<div class="popover">
-					<p>{{ informCsvStructureMessage }}</p>
-					<br>
-					<NcRichText :use-markdown="true"
-						:text="csvTemplateMarkdown" />
-				</div>
-			</NcPopover>
-		</div>
 		<div class="select-users-list">
 			<div v-if="allSelectedUsers.length === 0"
 				class="select-users-list-empty">
@@ -360,6 +363,11 @@ section.app-sidebar__tab--active {
 
 .select-users-wrapper :deep(.app-sidebar-tabs) {
 	margin-top: -10px !important;
+	flex: 1 1 120px !important;
+}
+
+.select-users-wrapper :deep(header.app-sidebar-header) {
+    display: none !important;
 }
 
 // Change the height of the modal container
@@ -453,8 +461,8 @@ section.app-sidebar__tab--active {
 
 .information-import {
 	position: absolute;
-	top: 108px;
-	right: 54px;
+	top: 12px;
+	right: 0px;
 	z-index: 9999;
 }
 

--- a/src/AddUsersTabs.vue
+++ b/src/AddUsersTabs.vue
@@ -376,6 +376,13 @@ section.app-sidebar__tab--active {
 	max-height: 900px !important;
 }
 
+// Fix : tabs implies a min-height of 256 that overlaps the user list
+.select-users-wrapper :deep(.app-sidebar-tabs__content) {
+	min-height: 60px !important;
+	height: auto !important;
+	padding-top: 20px;
+}
+
 // FIXME: Obivously we should at some point not randomly reuse the sidebar component
 // since this is not oficially supported
 .modal-container .app-sidebar {

--- a/src/GroupDetails.vue
+++ b/src/GroupDetails.vue
@@ -67,10 +67,12 @@
 			</div>
 		</div>
 		<UserTable :space-name="decodeURIComponent(decodeURIComponent($route.params.slug))" :editable="!isAddedGroup" />
-		<NcModal v-if="showSelectUsersModal"
-			@close="toggleShowSelectUsersModal">
-			<AddUsersTabs @close-sidebar="toggleShowSelectUsersModal" />
-		</NcModal>
+		<NcDialog v-if="showSelectUsersModal"
+			:name="t('workspace', 'Add users')"
+			size="normal"
+			@update:open="toggleShowSelectUsersModal">
+			<AddUsersTabs />
+		</NcDialog>
 		<AlertRemoveGroup v-if="showRemoveConnectedGroupModal"
 			:message="t('workspace', 'Warning, after removal of group <b>{groupname}</b>, its users will lose access to the <b>{spacename}</b> workspace, with the exception of:<br><br>- Workspace Managers (<b>WM-{spacename}</b>)<br>- users who are members of <b>Workspace groups</b> (prefixed <b>G-</b>)<br>- users who are members of another Added Group<br>- users manually added from the Workspace <b>{spacename}</b>', { groupname: decodeURIComponent(decodeURIComponent($route.params.slug)), spacename: $route.params.space }, null, { escape: false })"
 			@cancel="closeConnectedGroupModal"
@@ -88,7 +90,7 @@ import AlertRemoveGroup from './AlertRemoveGroup.vue'
 import NcActions from '@nextcloud/vue/components/NcActions'
 import NcActionButton from '@nextcloud/vue/components/NcActionButton'
 import NcActionInput from '@nextcloud/vue/components/NcActionInput'
-import NcModal from '@nextcloud/vue/components/NcModal'
+import NcDialog from '@nextcloud/vue/components/NcDialog'
 import AddUsersTabs from './AddUsersTabs.vue'
 import UserGroup from './services/Groups/UserGroup.js'
 import UserTable from './UserTable.vue'
@@ -97,7 +99,7 @@ export default {
 	name: 'GroupDetails',
 	components: {
 		AddUsersTabs,
-		NcModal,
+		NcDialog,
 		AlertRemoveGroup,
 		NcActions,
 		NcActionButton,

--- a/src/GroupDetails.vue
+++ b/src/GroupDetails.vue
@@ -237,10 +237,6 @@ export default {
 </script>
 
 <style>
-.icon-group {
-	min-width: 42px;
-	min-height: 42px;
-}
 
 .group-actions,
 .group-name,

--- a/src/LeftSidebar.vue
+++ b/src/LeftSidebar.vue
@@ -21,17 +21,20 @@
 -->
 <template>
 	<NcAppNavigation v-if="$root.$data.canAccessApp === 'true'">
-		<NcAppNavigationNewItem v-if="$root.$data.isUserGeneralAdmin === 'true'"
-			icon="icon-add"
-			:name="t('workspace', 'New space')"
-			@new-item="createSpace" />
-		<NcAppNavigationItem
-			:name="t('workspace', 'All spaces')"
-			:to="{path: '/'}">
-			<NcCounterBubble slot="counter">
-				{{ $store.state.countWorkspaces }}
-			</NcCounterBubble>
-		</NcAppNavigationItem>
+		<ul class="ws-navigation-header">
+			<NcAppNavigationNewItem v-if="$root.$data.isUserGeneralAdmin === 'true'"
+				icon="icon-add"
+				:name="t('workspace', 'New space')"
+				@new-item="createSpace" />
+			<li class="ws-navigation-spacer" />
+			<NcAppNavigationItem
+				:name="t('workspace', 'All spaces')"
+				:to="{path: '/'}">
+				<NcCounterBubble slot="counter">
+					{{ $store.state.countWorkspaces }}
+				</NcCounterBubble>
+			</NcAppNavigationItem>
+		</ul>
 		<template #list>
 			<SpaceMenuItem
 				v-for="(space, spaceName) in $store.state.spaces"
@@ -112,4 +115,10 @@ export default {
 .app-navigation-entry {
 	padding-right: 0px;
 }
-</style>
+.ws-navigation-header {
+	padding: var(--app-navigation-padding);
+}
+.ws-navigation-spacer {
+	height: var(--app-navigation-padding);
+}
+	</style>

--- a/src/MenuItemSelector.vue
+++ b/src/MenuItemSelector.vue
@@ -71,16 +71,25 @@ export default {
 	top: 0;
 	border-bottom-left-radius: 0;
 	border-bottom-right-radius: 0;
+  border-top-right-radius: var(--border-radius-element, var(--border-radius-pill));
+	border-top-left-radius: var(--border-radius-element, var(--border-radius-pill));
+	width: 100%;
 }
+
 .app-navigation-entry.space-middle-background{
 	top: 0;
 	bottom: 0;
 	border-radius: 0;
+	width: 100%;
 }
+
 .app-navigation-entry.space-last-background{
 	bottom: 0;
 	border-top-left-radius: 0;
 	border-top-right-radius: 0;
+  border-bottom-right-radius: var(--border-radius-element, var(--border-radius-pill));
+	border-bottom-left-radius: var(--border-radius-element, var(--border-radius-pill));
+	width: 100%;
 }
 
 </style>

--- a/src/SpaceDetails.vue
+++ b/src/SpaceDetails.vue
@@ -86,10 +86,12 @@
 			</div>
 		</div>
 		<UserTable :space-name="$route.params.space" />
-		<NcModal v-if="showSelectUsersModal"
-			@close="toggleShowSelectUsersModal">
-			<AddUsersTabs @close-sidebar="toggleShowSelectUsersModal" />
-		</NcModal>
+		<NcDialog v-if="showSelectUsersModal"
+			:name="t('workspace', 'Add users')"
+			size="normal"
+			@update:open="toggleShowSelectUsersModal">
+			<AddUsersTabs />
+		</NcDialog>
 		<SelectConnectedGroups v-if="showSelectConnectedGroups" @close="toggleShowConnectedGroups" />
 		<RemoveSpace v-if="showDelWorkspaceModal"
 			:space-name="$route.params.space"
@@ -107,7 +109,7 @@ import NcActions from '@nextcloud/vue/components/NcActions'
 import NcActionButton from '@nextcloud/vue/components/NcActionButton'
 import NcActionInput from '@nextcloud/vue/components/NcActionInput'
 import NcSelect from '@nextcloud/vue/components/NcSelect'
-import NcModal from '@nextcloud/vue/components/NcModal'
+import NcDialog from '@nextcloud/vue/components/NcDialog'
 import SelectConnectedGroups from './SelectConnectedGroups.vue'
 import RemoveSpace from './RemoveSpace.vue'
 import UserTable from './UserTable.vue'
@@ -124,7 +126,7 @@ export default {
 		NcEmptyContent,
 		NcActionButton,
 		NcActionInput,
-		NcModal,
+		NcDialog,
 		NcSelect,
 		SelectConnectedGroups,
 		RemoveSpace,


### PR DESCRIPTION
Story #3869

OK 3. menu latéral de gauche : remettre en place le système de sélection des WSP du menu de gauche (pour afficher le WSP "en cours" et ses sous-groupes (wsp et ajoutés) associés)
OK 4. menu latéral de gauche : le bouton "all workspaces" est trop petit + son rectangle bleu est coupé en bas
OK 5. menu latéral de gauche : le bouton "create a workspace" parait petit
OK 6. menu latéral de gauche : les icônes des groupes G- et ajoutés ne sont pas du tout alignées avec leur texte correspondant (le displayName du groupe)
OK 8. dans la page d'un WSP, en cliquant sur le bouton "+" en haut à droite : les icônes de "create a workspace group" et "add a group" ne sont pas alignées par rapport aux texte
OK 9. fenêtre modale d'ajout de users  : la fenêtre "add a user" est très grande + coupée en haut (l'espace sur les autres instances, avant nc31-31, était plus grand)
OK 10. fenêtre modale d'ajout de users  : il y a un trop grand espace entre le champ de recherche et la liste des utilisateur·ices sélectionné·es