### PR TITLE
- various OCS API fixes & script api-test.js

### DIFF
--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -26,6 +26,7 @@
 namespace OCA\Workspace\Controller;
 
 use OCA\Workspace\AppInfo\Application;
+use OCA\Workspace\Exceptions\NotFoundException;
 use OCA\Workspace\Service\UserService;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\TemplateResponse;
@@ -45,7 +46,13 @@ class PageController extends Controller {
 	 * @NoAdminRequired
 	 * @NOCSRFRequired
 	 */
-	public function index(): TemplateResponse {
+	public function index($path = ''): TemplateResponse {
+		if (strpos($path, 'api/v') === 0) {
+			// avoid non existing API routes to be handled by this controller
+			// (because of catchall route)
+			throw new NotFoundException('Not found');
+		}
+
 		Util::addScript(Application::APP_ID, 'workspace-main');		// js/workspace-main.js
 		Util::addStyle(Application::APP_ID, 'workspace-style');		// css/workspace-style.css
 

--- a/lib/Db/SpaceMapper.php
+++ b/lib/Db/SpaceMapper.php
@@ -80,14 +80,13 @@ class SpaceMapper extends QBMapper {
 	}
 
 	/**
-	 * @deprecated
 	 * @see WorkspaceController->destroy().
 	 */
 	public function deleteSpace(int $id): void {
 		$qb = $this->db->getQueryBuilder();
 
 		$qb->delete('work_spaces')
-			->where($qb->expr()->eq('id', $qb->createNamedParameter($id))
+			->where($qb->expr()->eq('space_id', $qb->createNamedParameter($id))
 			)
 			->execute();
 	}

--- a/lib/Group/SubGroups/SubGroup.php
+++ b/lib/Group/SubGroups/SubGroup.php
@@ -69,7 +69,7 @@ class SubGroup {
 		$group = $this->groupManager->get($gid);
 
 		$groupsSearched = $this->groupManager->search($displayName);
-		$groupnames = array_map(fn($group) => $group->getDisplayName(), $groupsSearched);
+		$groupnames = array_map(fn ($group) => $group->getDisplayName(), $groupsSearched);
 
 		if (!is_null($group)) {
 			if (in_array($displayName, $groupnames)) {

--- a/lib/ResponseDefinitions.php
+++ b/lib/ResponseDefinitions.php
@@ -48,7 +48,7 @@ namespace OCA\Workspace;
  * 		users: list<array{}>,
  * 		added_groups: list<array{}>
  * }
- * 
+ *
  * @psalm-type WorkspaceGroupInfo = array{
  * 		gid: string,
  * 		displayName: string,
@@ -56,7 +56,7 @@ namespace OCA\Workspace;
  * 		usersCount: int,
  * 		slug: string
  * }
- * 
+ *
  * @psalm-type WorkspaceFindGroups = array<string, WorkspaceGroupInfo>
  *
  * @psalm-type WorkspaceSpaceDelete = array{
@@ -66,7 +66,7 @@ namespace OCA\Workspace;
  * 		groupfolder_id: int,
  * 		state: string
  * }
- * 
+ *
  * @psalm-type WorkspaceConfirmationMessage = array{
  * 		message: string
  * }

--- a/lib/Space/SpaceManager.php
+++ b/lib/Space/SpaceManager.php
@@ -167,7 +167,7 @@ class SpaceManager {
 
 		return $groupsFormatted;
 	}
-	
+
 	/**
 	 * Create a subgroup to a workspace and attaches it in.
 	 * @param int $id is the space id.
@@ -331,6 +331,8 @@ class SpaceManager {
 			}
 		}
 
+		$this->spaceMapper->deleteSpace($spaceId);
+
 		$folderId = $space['groupfolder_id'];
 		$this->folderHelper->removeFolder($folderId);
 	}
@@ -485,7 +487,7 @@ class SpaceManager {
 		if (!$userGroup->inGroup($user)) {
 			$userGroup->addUser($user);
 		}
-		
+
 		$managerGroup->addUser($user);
 		$this->adminGroup->addUser($user, $spaceId);
 	}

--- a/openapi.json
+++ b/openapi.json
@@ -1,0 +1,1316 @@
+{
+    "openapi": "3.0.3",
+    "info": {
+        "title": "workspace",
+        "version": "0.0.1",
+        "description": "Create Groupfolders with delegated management",
+        "license": {
+            "name": "agpl"
+        }
+    },
+    "components": {
+        "securitySchemes": {
+            "basic_auth": {
+                "type": "http",
+                "scheme": "basic"
+            },
+            "bearer_auth": {
+                "type": "http",
+                "scheme": "bearer"
+            }
+        },
+        "schemas": {
+            "Capabilities": {
+                "oneOf": [
+                    {
+                        "type": "object",
+                        "required": [
+                            "workspace"
+                        ],
+                        "properties": {
+                            "workspace": {
+                                "$ref": "#/components/schemas/Capabilities"
+                            }
+                        }
+                    },
+                    {
+                        "type": "array",
+                        "maxItems": 0
+                    }
+                ]
+            },
+            "ConfirmationMessage": {
+                "type": "object",
+                "required": [
+                    "message"
+                ],
+                "properties": {
+                    "message": {
+                        "type": "string"
+                    }
+                }
+            },
+            "FindGroups": {
+                "type": "object",
+                "additionalProperties": {
+                    "$ref": "#/components/schemas/GroupInfo"
+                }
+            },
+            "GroupInfo": {
+                "type": "object",
+                "required": [
+                    "gid",
+                    "displayName",
+                    "types",
+                    "usersCount",
+                    "slug"
+                ],
+                "properties": {
+                    "gid": {
+                        "type": "string"
+                    },
+                    "displayName": {
+                        "type": "string"
+                    },
+                    "types": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "usersCount": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "slug": {
+                        "type": "string"
+                    }
+                }
+            },
+            "OCSMeta": {
+                "type": "object",
+                "required": [
+                    "status",
+                    "statuscode"
+                ],
+                "properties": {
+                    "status": {
+                        "type": "string"
+                    },
+                    "statuscode": {
+                        "type": "integer"
+                    },
+                    "message": {
+                        "type": "string"
+                    },
+                    "totalitems": {
+                        "type": "string"
+                    },
+                    "itemsperpage": {
+                        "type": "string"
+                    }
+                }
+            },
+            "Space": {
+                "type": "object",
+                "required": [
+                    "id",
+                    "mount_point",
+                    "groups",
+                    "quota",
+                    "size",
+                    "acl",
+                    "manage",
+                    "groupfolder_id",
+                    "name",
+                    "color_code",
+                    "userCount",
+                    "users",
+                    "added_groups"
+                ],
+                "properties": {
+                    "id": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "mount_point": {
+                        "type": "string"
+                    },
+                    "groups": {
+                        "type": "array",
+                        "items": {
+                            "type": "object"
+                        }
+                    },
+                    "quota": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "size": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "acl": {
+                        "type": "boolean"
+                    },
+                    "manage": {
+                        "type": "array",
+                        "items": {
+                            "type": "object"
+                        }
+                    },
+                    "groupfolder_id": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "color_code": {
+                        "type": "string"
+                    },
+                    "userCount": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "users": {
+                        "type": "array",
+                        "items": {
+                            "type": "object"
+                        }
+                    },
+                    "added_groups": {
+                        "type": "array",
+                        "items": {
+                            "type": "object"
+                        }
+                    }
+                }
+            },
+            "SpaceDelete": {
+                "type": "object",
+                "required": [
+                    "name",
+                    "groups",
+                    "id",
+                    "groupfolder_id",
+                    "state"
+                ],
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "groups": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "id": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "groupfolder_id": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "state": {
+                        "type": "string"
+                    }
+                }
+            }
+        }
+    },
+    "paths": {
+        "/index.php/apps/workspace/api/v1/spaces/{id}": {
+            "get": {
+                "operationId": "workspace_api_ocs-find",
+                "summary": "Returns a workspace by its ID",
+                "tags": [
+                    "workspace"
+                ],
+                "security": [
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "Represents the ID of a workspace",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    },
+                    {
+                        "name": "OCS-APIRequest",
+                        "in": "header",
+                        "description": "Required to be true for the API request to pass",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Workspace returned",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "$ref": "#/components/schemas/Space"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Workspace not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "patch": {
+                "operationId": "workspace_api_ocs-edit",
+                "summary": "Edit workspace name, color and quota",
+                "tags": [
+                    "workspace"
+                ],
+                "security": [
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "requestBody": {
+                    "required": false,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {
+                                        "type": "string",
+                                        "nullable": true,
+                                        "description": "Workspace name (optional)"
+                                    },
+                                    "color": {
+                                        "type": "string",
+                                        "nullable": true,
+                                        "default": null,
+                                        "description": "Workspace color (optional)"
+                                    },
+                                    "quota": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "nullable": true,
+                                        "default": null,
+                                        "description": "Workspace quota in bytes (optional, -3 means unlimited, 0 means no quota)"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "Represents the ID of a workspace",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    },
+                    {
+                        "name": "OCS-APIRequest",
+                        "in": "header",
+                        "description": "Required to be true for the API request to pass",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Workspace returned",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "$ref": "#/components/schemas/Space"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Workspace not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "operationId": "workspace_api_ocs-delete",
+                "summary": "Remove a workspace by id",
+                "tags": [
+                    "workspace"
+                ],
+                "security": [
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "of a workspace to delete",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    },
+                    {
+                        "name": "OCS-APIRequest",
+                        "in": "header",
+                        "description": "Required to be true for the API request to pass",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Workspace deleted successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "$ref": "#/components/schemas/SpaceDelete"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Workspace not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "nullable": true
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/index.php/apps/workspace/api/v1/spaces": {
+            "post": {
+                "operationId": "workspace_api_ocs-create",
+                "summary": "Create a new workspace",
+                "tags": [
+                    "workspace"
+                ],
+                "security": [
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "name"
+                                ],
+                                "properties": {
+                                    "name": {
+                                        "type": "string",
+                                        "description": "The workspace name"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "name": "OCS-APIRequest",
+                        "in": "header",
+                        "description": "Required to be true for the API request to pass",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Workspace created successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "$ref": "#/components/schemas/Space"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid workspace name",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "nullable": true
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "409": {
+                        "description": "Workspace with this name already exists",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "nullable": true
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/index.php/apps/workspace/api/v1/spaces/{id}/groups": {
+            "get": {
+                "operationId": "workspace_api_ocs-find-groups-by-space-id",
+                "summary": "Returns the groups associated with a workspace.",
+                "tags": [
+                    "workspace-groups"
+                ],
+                "security": [
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "Represents the ID of the workspace.",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    },
+                    {
+                        "name": "OCS-APIRequest",
+                        "in": "header",
+                        "description": "Required to be true for the API request to pass",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Groups of the specified workspace returned successfully.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "$ref": "#/components/schemas/FindGroups"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "operationId": "workspace_api_ocs-create-sub-group",
+                "summary": "Create a new subgroup for a workspace",
+                "tags": [
+                    "workspace-groups"
+                ],
+                "security": [
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "name"
+                                ],
+                                "properties": {
+                                    "name": {
+                                        "type": "string",
+                                        "description": "The subgroup name"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "Represents the ID of the workspace.",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    },
+                    {
+                        "name": "OCS-APIRequest",
+                        "in": "header",
+                        "description": "Required to be true for the API request to pass",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Subgroup created successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "$ref": "#/components/schemas/Space"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "409": {
+                        "description": "Subgroup with this name already exists",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "nullable": true
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/index.php/apps/workspace/api/v1/spaces/{id}/users": {
+            "post": {
+                "operationId": "workspace_api_ocs-add-users-in-workspace",
+                "summary": "Adds users to the workspace by id.",
+                "tags": [
+                    "workspace-users"
+                ],
+                "security": [
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "uids"
+                                ],
+                                "properties": {
+                                    "uids": {
+                                        "type": "array",
+                                        "description": "Represents the user uids to add to the workspace.",
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "Represents the ID of the workspace.",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    },
+                    {
+                        "name": "OCS-APIRequest",
+                        "in": "header",
+                        "description": "Required to be true for the API request to pass",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Confirmation message indicating that users have been added successfully.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "$ref": "#/components/schemas/ConfirmationMessage"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "User not found in the instance.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "nullable": true
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "operationId": "workspace_api_ocs-remove-users-in-workspace",
+                "summary": "Remove users from a workspace",
+                "tags": [
+                    "workspace-users"
+                ],
+                "security": [
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "Represents the ID of the workspace.",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    },
+                    {
+                        "name": "uids[]",
+                        "in": "query",
+                        "description": "Represents the user uids to remove to the workspace.",
+                        "required": true,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "name": "OCS-APIRequest",
+                        "in": "header",
+                        "description": "Required to be true for the API request to pass",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "Confirmation for users removed from the workspace."
+                    },
+                    "404": {
+                        "description": "User not found in the instance.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "nullable": true
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/index.php/apps/workspace/api/v1/spaces/{id}/workspace-manager": {
+            "post": {
+                "operationId": "workspace_api_ocs-add-user-as-workspace-manager",
+                "summary": "Add user as a workspace manager",
+                "tags": [
+                    "workspace-users"
+                ],
+                "security": [
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "uid"
+                                ],
+                                "properties": {
+                                    "uid": {
+                                        "type": "string",
+                                        "description": "Represents the user uid to add as a workspace manager."
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "Represents the ID of the workspace.",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    },
+                    {
+                        "name": "OCS-APIRequest",
+                        "in": "header",
+                        "description": "Required to be true for the API request to pass",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Confirmation for users added to the workspace.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "object"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "User not found in the instance.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "object"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "operationId": "workspace_api_ocs-remove-user-as-workspace-manager",
+                "summary": "Remove user as a workspace manager",
+                "tags": [
+                    "workspace-users"
+                ],
+                "security": [
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "Represents the ID of the workspace.",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    },
+                    {
+                        "name": "uid",
+                        "in": "query",
+                        "description": "Represents the user uid to remove as a workspace manager.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "OCS-APIRequest",
+                        "in": "header",
+                        "description": "Required to be true for the API request to pass",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Confirmation for users removed from the workspace.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "object"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "User not found in the instance.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "object"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "tags": []
+}

--- a/scripts/api-test.conf.sample
+++ b/scripts/api-test.conf.sample
@@ -1,0 +1,5 @@
+[api]
+nextcloud = 'https://mynextcloud.com/'
+login = 'myadminlogin'
+key = 'myapp-nextcloud-key'
+user = 'myuser'

--- a/scripts/api-test.js
+++ b/scripts/api-test.js
@@ -1,0 +1,445 @@
+#!/usr/local/bin/node
+
+/**
+ * To use this script, you need to install Node.JS 
+ * 
+ * - run `npm install` to install the required dependencies in this folder
+ * 
+ * - go on Nextcloud and create an app password for your user
+ * 
+ *  - report the login and the key in the api-test.conf file
+ * 
+ * 	- set the nextcloud url in the api-test.conf file
+ * 
+ * - run 'npm run api -- -v' to execute the script
+ * 
+ */
+
+import yargs from "yargs";
+import axios from "axios";
+import toml from "toml";
+import convict from "convict";
+import readline from 'node:readline/promises';
+import { type } from "node:os";
+
+// our .conf is using TOML format
+convict.addParser({ extension: 'conf', parse: toml.parse });
+const rl = readline.createInterface({ input: process.stdin, output: process.stdout});
+
+const _exit = process.exit;
+var verbose = false;
+
+const worskpace_api = 'index.php/apps/workspace/api/v1/'
+
+function WorkspaceApi(nextcloud, login, key) {
+	this.login = login
+	this.key = key;
+	this.url = nextcloud + worskpace_api;
+	this._error = null;
+}
+
+WorkspaceApi.prototype._api = async function(route, method = 'get', data = null) {
+	const url = this.url + route;
+	this._error = null;
+	try {
+		let request = {
+            url: url,
+            method: method,
+            auth: {
+                username: this.login,
+                password: this.key
+            },
+            headers: {
+                'OCS-APIRequest': true,
+            }
+        };
+		if (data) {
+			request.data = data;
+		}
+        const response = await axios(request);
+        return response.data.ocs ? response.data.ocs.data : response.data;
+	} catch (error) {
+		this._error = error;
+        return null;
+    }
+};
+
+WorkspaceApi.prototype.logError = function (message) {
+	if (this._error) {
+		if (verbose) {
+			console.error('Error: ' + message);
+			console.error('Status: ' + this._error.response.status);
+			console.error('Data: ' + JSON.stringify(this._error.response.data, null, 2));
+		} else {
+			console.error('Error: ' + message + ' (status: ' + this._error.response.status + ')');
+			if (this._error.response.data && this._error.response.data.message) {
+				console.error('Message: ' + this._error.response.data.message);
+			}
+		}
+	}
+}
+
+
+WorkspaceApi.prototype.get = async function(id) {
+	return await this._api('spaces/' + id);
+};
+
+WorkspaceApi.prototype.delete = async function(id) {
+	return await this._api('spaces/' + id, 'delete');
+};
+
+WorkspaceApi.prototype.listAll = async function() {
+	return await this._api('spaces');
+};
+
+WorkspaceApi.prototype.create = async function(name) {
+	return await this._api('spaces', 'post', { name: name });
+};
+
+WorkspaceApi.prototype.edit = async function(id, params = null) {
+	return await this._api('spaces/'+id, 'patch', params);
+};
+
+WorkspaceApi.prototype.addSubGroup = async function(id, name) {
+	return await this._api('spaces/'+id+'/groups', 'post', { name: name });
+};
+
+WorkspaceApi.prototype.getGroups = async function(id) {
+	return await this._api('spaces/'+id+'/groups', 'get');
+};
+
+WorkspaceApi.prototype.setWM = async function(id, uid, isWM = true) {
+	return await this._api('spaces/'+id+'/workspace-manager', isWM ? 'post' : 'delete', { uid: uid });
+};
+
+WorkspaceApi.prototype.addUsers = async function(id, uids) {
+	return await this._api('spaces/'+id+'/users', 'post', { uids: uids });
+};
+WorkspaceApi.prototype.removeUsers = async function(id, uids) {
+	return await this._api('spaces/'+id+'/users', 'delete', { uids: uids });
+};
+
+async function ask_continue() {
+	const res = await rl.question("Continue ? ([y]/n) ");
+	if (res === 'y' || res === 'Y' || res === '') {
+		return true;
+	}
+	return false;
+}
+
+/**
+ * Main program.
+ */
+
+async function main() {
+	
+	// Reading configuration
+	const configPath = options.conf;
+	const config = convict({
+		api: {
+			nextcloud: 'https://nextcloud.com/',
+			login: 'admin',
+			key: 'xxx',
+			user: 'admin',
+		},
+	});
+	config.loadFile(configPath);
+	const apiConf = config.get('api');
+
+	let current_workspace = options.id;
+	verbose = options.verbose;
+
+	// Verbose mode
+	if (verbose) {
+		console.log('Nextcloud api: ' + apiConf.nextcloud);
+	}
+
+	// create api
+	const workspaceApi = new WorkspaceApi(apiConf.nextcloud, apiConf.login, apiConf.key);
+
+	if (options.step <= 1) {
+		console.log('Step 1: Get non-existing workspace');
+		const res = await workspaceApi.get(9999); // trying to get a non-existing workspace
+		if (res === null) {
+			workspaceApi.logError('Error while getting workspace 9999');
+		}
+		if (!options.yes) {
+			if (!await ask_continue()) { return; } 
+		}
+	}
+	// list all workspaces
+	if (options.step <= 2) {
+		console.log('Step 2: List all workspaces');
+		const res = await workspaceApi.listAll(); // trying to get a non-existing workspace
+		if (res === null) {
+			workspaceApi.logError('Error while getting workspace 9999');
+		}
+		if (!options.yes) {
+			if (!await ask_continue()) { return; } 
+		}
+	}
+	
+	// create workspace
+	if (options.step <= 3) {
+		console.log('Step 3: Creating a workspace "Test Workspace"');
+		const res = await workspaceApi.create('Test Workspace');
+		if (res === null) {
+			workspaceApi.logError('Error while creating workspace');
+		} else {
+			if (verbose) {
+				console.log('Created workspace:');
+				console.log(JSON.stringify(res, null, 2));
+			} else {
+				console.log('Created workspace: ' + res.id + ' - ' + res.name);
+			}
+		}
+		if (!options.yes) {
+			if (!await ask_continue()) { return; } 
+		}
+		current_workspace = res.id; // save the created workspace id for next steps
+	}
+	
+	// get existing workspace
+	if (options.step <= 4) {
+		console.log('Step 4: Get Created Workspace');
+		const spaceId = current_workspace; // use the created workspace id or a default one
+		const res = await workspaceApi.get(spaceId);
+		if (res === null) {
+			workspaceApi.logError('Error while getting workspace ' + spaceId);
+		} else {
+			if (verbose) {
+				console.log('Workspace ' + spaceId);
+				console.log(JSON.stringify(res, null, 2));
+			} else {
+				console.log('Workspace: ' + res.id + ' - ' + res.name + ' - '
+					+ Object.keys(res.groups).length + ' groups - '
+					+ Object.keys(res.added_groups).length + ' added groups - '
+					+ Object.keys(res.users).length + ' users');
+			}
+		}
+		if (!options.yes) {
+			if (!await ask_continue()) { return; } 
+		}
+	}
+
+	// edit existing workspace
+	if (options.step <= 5) {
+		console.log('Step 5: Edit Created Workspace (name, color, quota)');
+		const spaceId = current_workspace;
+		const res = await workspaceApi.edit(spaceId, {name: 'Test Workspace Modified', color: '#ff0000', quota: 1000000000});
+		if (res === null) {
+			workspaceApi.logError('Error while editing workspace ' + spaceId);
+		} else {
+			if (verbose) {
+				console.log('Workspace ' + spaceId);
+				console.log(JSON.stringify(res, null, 2));
+			} else {
+				console.log('Workspace: ' + spaceId + ' - ' + res.name + ' - ' + res.color + ' - ' + res.quota + ' bytes');
+			}
+		}
+		if (!options.yes) {
+			if (!await ask_continue()) { return; } 
+		}
+	}
+
+	// Create subgroup for the workspace
+	if (options.step <= 6) {
+		console.log('Step 6: Create a subgroup "My SubGroup" in the created workspace');
+		const spaceId = current_workspace;
+		const res = await workspaceApi.addSubGroup(spaceId, 'MySubGroup');
+		if (res === null) {
+			workspaceApi.logError('Error while adding subgroup ' + spaceId);
+		} else {
+			if (verbose) {
+				console.log('Workspace ' + spaceId);
+				console.log(JSON.stringify(res, null, 2));
+			} else {
+				console.log('Workspace: ' + spaceId + ' - Group ID: ' + res.gid);
+			}
+		}
+		if (!options.yes) {
+			if (!await ask_continue()) { return; } 
+		}
+	}
+
+	// List subgroup for the workspace
+	if (options.step <= 7) {
+		console.log('Step 7: List all groups in the created workspace');
+		const spaceId = current_workspace;
+		const res = await workspaceApi.getGroups(spaceId);
+		if (res === null) {
+			workspaceApi.logError('Error while getting subgroups ' + spaceId);
+		} else {
+			if (verbose) {
+				console.log('Workspace: ' + spaceId);
+				console.log(JSON.stringify(res, null, 2));
+			} else {
+				console.log('Workspace: ' + spaceId);
+				Object.values(res).forEach((group) => {
+					console.log(' - Group ID: ' + group.gid + ' - Name: ' + group.displayName + ' - Users : ' + group.usersCount);
+				});
+			}
+		}
+		if (!options.yes) {
+			if (!await ask_continue()) { return; } 
+		}
+	}
+
+	// Add user as in the workspace
+	if (options.step <= 8 ) {
+		console.log('Step 8: Add user in the Workspace');
+		const spaceId = current_workspace;
+		const res = await workspaceApi.addUsers(spaceId, [ apiConf.user ]);
+		if (res === null) {
+			workspaceApi.logError('Error while adding user ' + apiConf.user + ' in space ' + spaceId);
+		} else {
+			if (verbose) {
+				console.log('Workspace: ' + spaceId);
+				console.log(JSON.stringify(res, null, 2));
+			} else {
+				console.log('Workspace: ' + spaceId);
+				console.log(res.message);
+			}
+		}
+		if (!options.yes) {
+			if (!await ask_continue()) { return; } 
+		}
+	}
+
+	// Promote user as Workspace Manager
+	if (options.step <= 9 ) {
+		console.log('Step 9: Promote user as Workspace Manager');
+		const spaceId = current_workspace;
+		const res = await workspaceApi.setWM(spaceId, apiConf.user, true);
+		if (res === null) {
+			workspaceApi.logError('Error while promoting user ' + apiConf.user + ' in space ' + spaceId);
+		} else {
+			if (verbose) {
+				console.log('Workspace: ' + spaceId);
+				console.log(JSON.stringify(res, null, 2));
+			} else {
+				console.log('Workspace: ' + spaceId);
+				console.log('User: ' + res.uid + ' was promoted');
+			}
+		}
+		if (!options.yes) {
+			if (!await ask_continue()) { return; } 
+		}
+	}
+
+	// Degrade user as Workspace Manager
+	if (options.step <= 10 ) {
+		console.log('Step 10: Degrade user from Workspace Manager as simple user');
+		const spaceId = current_workspace;
+		const res = await workspaceApi.setWM(spaceId, apiConf.user, false);
+		if (res === null) {
+			workspaceApi.logError('Error while degrading user ' + apiConf.user + ' from space '+ spaceId);
+		} else {
+			if (verbose) {
+				console.log('Workspace: ' + spaceId);
+				console.log(JSON.stringify(res, null, 2));
+			} else {
+				console.log('Workspace: ' + spaceId);
+				console.log('User: ' + apiConf.user + ' was degraded as simple user');
+			}
+		}
+		if (!options.yes) {
+			if (!await ask_continue()) { return; } 
+		}
+	}
+
+	// Remove user from Workspace Manager
+	if (options.step <= 11 ) {
+		console.log('Step 11: Remove user from Workspace Manager');
+		const spaceId = current_workspace;
+		const res = await workspaceApi.removeUsers(spaceId, [ apiConf.user ]);
+		if (res === null) {
+			workspaceApi.logError('Error while removing user ' + apiConf.user + ' from space ' + spaceId);
+		} else {
+			if (verbose) {
+				console.log('Workspace: ' + spaceId);
+				console.log(JSON.stringify(res, null, 2));
+			} else {
+				console.log('Workspace: ' + spaceId);
+				console.log('User: ' + apiConf.user + ' was removed');
+			}
+		}
+		if (!options.yes) {
+			if (!await ask_continue()) { return; } 
+		}
+	}
+
+	// Delete existing workspace
+	if (options.step <= 99 && current_workspace) {
+		console.log('Step 99: Delete Created Workspace');
+		const res = await workspaceApi.delete(current_workspace);
+		if (res === null) {
+			workspaceApi.logError('Error while deleting workspace ' + current_workspace);
+		} else {
+			if (verbose) {
+				console.log('Deleted workspace:');
+				console.log(JSON.stringify(res, null, 2));
+			} else {
+				console.log('Deleted workspace: ' + current_workspace);
+			}
+		}
+		if (!options.yes && options.step == 0) {
+			if (!await ask_continue()) { return; } 
+		}
+	}
+
+	// Create a workspace again with forbidden characters
+	if (options.step <= 110) {
+		console.log('Step 110: Creating a workspace "Test/Workspace"');
+		const res = await workspaceApi.create('Test/Workspace');
+		if (res === null) {
+			workspaceApi.logError('Error while creating workspace');
+		} else {
+			if (verbose) {
+				console.log('Created workspace:');
+				console.log(JSON.stringify(res, null, 2));
+			} else {
+				console.log('Created workspace: ' + res.id + ' - ' + res.name);
+			}
+		}
+		if (!options.yes) {
+			if (!await ask_continue()) { return; } 
+		}
+	}
+}
+
+// -----------------------------------------------------------------------------
+// arguments
+// -----------------------------------------------------------------------------
+const options = yargs(process.argv.slice(2))
+ .usage("Usage: $0 [options]")
+ .options("c", {alias: "conf", describe: "Config file", demandOption: false, boolean: false, default: 'api-test.conf'})
+	.options("s", { alias: "step", describe: "Run from step:\n"
+		+ " 1 : get non existing workspace (will fail)\n"
+		+ " 2 : list all workspaces\n"
+		+ " 3 : create a workspace\n"
+		+ " 4 : get existing workspace\n"
+		+ " 5 : edit existing workspace\n"
+		+ " 6 : create subgroup\n"
+		+ " 7 : list groups\n"
+		+ " 8 : add user in workspace\n"
+		+ " 9 : promote user as Workspace Manager\n"
+		+ " 10 : degrade user from Workspace Manager as simple user\n"
+		+ " 11 : remove user from workspace\n"
+		+ " 99: delete workspace\n"
+		+ " 110: create workspace with forbidden characters (will fail)\n"
+		, boolean: false, default: 0
+	})
+ .options("y", {alias: "yes", describe: "Answer yes to all waiting inputs", boolean: true, default: false })
+ .options("i", {alias: "id", describe: "Use this id as working workspace", boolean: false, default: 0})
+ .options("v", { alias: "verbose", describe: "Verbose mode", boolean: true, default: false })
+ .help('h')
+ .alias('V', 'version')
+ .alias('h', 'help')
+ .strictOptions(true)
+ .argv;
+
+if (!_exit.exited) {
+	await main();
+}
+rl.close();

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -1,0 +1,18 @@
+{
+	"name": "worskpace-api-calls",
+	"version": "1.0.0",
+	"description": "Api calls for workspace",
+	"main": "api-test.js",
+	"type": "module",
+	"scripts": {
+		"api": "node api-test.js"
+	},
+	"dependencies": {
+		"axios": "^1.6.0",
+		"convict": "^6.2.4",
+		"toml": "^3.0.0",
+		"yargs": "^18.0.0"
+	},
+	"author": "Sébastien Marinier",
+	"license": "MIT"
+}

--- a/tests/Unit/Controller/WorkspaceApiOcsControllerTest.php
+++ b/tests/Unit/Controller/WorkspaceApiOcsControllerTest.php
@@ -27,11 +27,11 @@ namespace OCA\Workspace\Tests\Unit\Controller;
 use Mockery;
 use OCA\Workspace\Controller\WorkspaceApiOcsController;
 use OCA\Workspace\Db\Space;
+use OCA\Workspace\Db\SpaceMapper;
 use OCA\Workspace\Exceptions\InvalidParamException;
 use OCA\Workspace\Exceptions\NotFoundException;
-use OCA\Workspace\Service\Validator\WorkspaceEditParamsValidator;
 use OCA\Workspace\Service\Group\WorkspaceManagerGroup;
-use OCA\Workspace\Db\SpaceMapper;
+use OCA\Workspace\Service\Validator\WorkspaceEditParamsValidator;
 use OCA\Workspace\Space\SpaceManager;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\DataResponse;
@@ -58,7 +58,7 @@ class WorkspaceApiOcsControllerTest extends TestCase {
 	private SpaceMapper&MockObject $spaceMapper;
 	private string $appName;
 	private WorkspaceApiOcsController $controller;
-	
+
 	public function setUp(): void {
 		$this->appName = 'workspace';
 		$this->editValidator = $this->createMock(WorkspaceEditParamsValidator::class);
@@ -68,7 +68,7 @@ class WorkspaceApiOcsControllerTest extends TestCase {
 		$this->spaceManager = $this->createMock(SpaceManager::class);
 		$this->spaceMapper = $this->createMock(SpaceMapper::class);
 		$this->userManager = $this->createMock(IUserManager::class);
-		
+
 		$this->controller = new WorkspaceApiOcsController(
 			$this->request,
 			$this->logger,
@@ -218,7 +218,7 @@ class WorkspaceApiOcsControllerTest extends TestCase {
 		$expected = new DataResponse([ 'gid' => 'SPACE-G-HR-1' ], Http::STATUS_CREATED);
 		$actual = $this->controller->createSubGroup($id, $groupname);
 
-    	if (!($actual instanceof DataResponse) || !($expected instanceof DataResponse)) {
+		if (!($actual instanceof DataResponse) || !($expected instanceof DataResponse)) {
 			return;
 		}
 
@@ -227,11 +227,11 @@ class WorkspaceApiOcsControllerTest extends TestCase {
 		$this->assertEquals(Http::STATUS_CREATED, $actual->getStatus());
 		$this->assertEquals($expected, $actual);
 		$this->assertEquals($expected->getData(), $actual->getData());
-  	}
+	}
 
 	public function testCreateReturnsValidDataResponse(): void {
 		$spacename = 'Space01';
-		
+
 		$this->spaceManager
 			->expects($this->once())
 			->method('create')
@@ -348,8 +348,8 @@ class WorkspaceApiOcsControllerTest extends TestCase {
 					'SPACE-GE-33' => [
 						'gid' => 'SPACE-GE-33',
 						'displayName' => 'WM-Space33',
-						'types' =>
-							[
+						'types'
+							=> [
 								'Database'
 							],
 						'usersCount' => 0,
@@ -358,8 +358,8 @@ class WorkspaceApiOcsControllerTest extends TestCase {
 					'SPACE-U-33' => [
 						'gid' => 'SPACE-U-33',
 						'displayName' => 'U-Space33',
-						'types' =>
-							[
+						'types'
+							=> [
 								'Database'
 							],
 						'usersCount' => 0,
@@ -470,7 +470,7 @@ class WorkspaceApiOcsControllerTest extends TestCase {
 			Http::STATUS_OK
 		)
 		;
- 
+
 		if (!($actual instanceof DataResponse) || !($expected instanceof DataResponse)) {
 			return;
 		}
@@ -525,7 +525,7 @@ class WorkspaceApiOcsControllerTest extends TestCase {
 			->method('getSpaceName')
 			->willReturn($spacename)
 		;
-		
+
 		$actual = $this->controller->addUsersInWorkspace($spaceId, $uids);
 
 		$expected = new DataResponse(
@@ -586,7 +586,7 @@ class WorkspaceApiOcsControllerTest extends TestCase {
 	public function testEdit(): void {
 		$id = 1;
 		$params = [
-			'name' => 'Espace02',
+			'name' => 'Espace02 Modified',
 			'quota' => 214748364800, // 200Gb
 			'color' => '#ACB5AC',
 		];
@@ -668,7 +668,7 @@ class WorkspaceApiOcsControllerTest extends TestCase {
 		$expected = new DataResponse($params, Http::STATUS_OK);
 
 		/** @var DataResponse */
-		$actual = $this->controller->edit($id, $params);
+		$actual = $this->controller->edit($id, $params['name'], $params['color'], $params['quota']);
 
 		$this->assertEquals($expected, $actual);
 		$this->assertEquals($expected->getData(), $actual->getData());
@@ -678,7 +678,7 @@ class WorkspaceApiOcsControllerTest extends TestCase {
 	public function testShouldAddUserAsWorkspaceManager(): void {
 		$uid = 'user1';
 		$id = 1;
-		
+
 		$user = $this->createMock(IUser::class);
 
 		$this->userManager
@@ -717,7 +717,7 @@ class WorkspaceApiOcsControllerTest extends TestCase {
 		$this->expectException(InvalidParamException::class);
 		$this->expectExceptionMessage('The name key must be a string');
 
-		$this->controller->edit($id, $params);
+		$this->controller->edit($id, $params['name']);
 	}
 
 	public function testEditWithQuotaParamInString(): void {
@@ -735,7 +735,7 @@ class WorkspaceApiOcsControllerTest extends TestCase {
 		$this->expectException(InvalidParamException::class);
 		$this->expectExceptionMessage('The quota key must be a integer');
 
-		$this->controller->edit($id, $params);
+		$this->controller->edit($id, null, null, $params['quota']);
 	}
 
 	public function testEditWithColorParamInInteger(): void {
@@ -753,7 +753,7 @@ class WorkspaceApiOcsControllerTest extends TestCase {
 		$this->expectException(InvalidParamException::class);
 		$this->expectExceptionMessage('The color key must be a string');
 
-		$this->controller->edit($id, $params);
+		$this->controller->edit($id, null, $params['color']);
 	}
 
 	public function testShouldThrowOcsNotFoundWhenAddingUserAsWorkspaceManager(): void {

--- a/tests/Unit/Group/SubGroups/SubGroupTest.php
+++ b/tests/Unit/Group/SubGroups/SubGroupTest.php
@@ -4,7 +4,6 @@ namespace OCA\Workspace\Tests\Unit\Group\SubGroups;
 
 use OCA\Workspace\Exceptions\GroupException;
 use OCA\Workspace\Group\SubGroups\SubGroup;
-use OCP\AppFramework\OCS\OCSBadRequestException;
 use OCP\IGroup;
 use OCP\IGroupManager;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -37,7 +36,7 @@ class SubGroupTest extends TestCase {
 			->with($displayName)
 			->willReturn([])
 		;
-		
+
 		$this->groupManager
 			->expects($this->once())
 			->method('get')
@@ -70,7 +69,7 @@ class SubGroupTest extends TestCase {
 		$id = 1;
 		$spacename = 'Espace01';
 
-		$gidToSet = sprintf('%s%s-%s', SubGroup::PREFIX_GID, $groupname . "1", $id);
+		$gidToSet = sprintf('%s%s-%s', SubGroup::PREFIX_GID, $groupname . '1', $id);
 		$displayName = sprintf('%s%s-%s', SubGroup::PREFIX_DISPLAY_NAME, "$groupname", $spacename);
 
 		$existingGroup = $this->createMock(IGroup::class);
@@ -125,7 +124,7 @@ class SubGroupTest extends TestCase {
 				$this->onConsecutiveCalls($groupDuplicated)
 			)
 		;
-		
+
 		$this->groupManager
 			->expects($this->once())
 			->method('search')
@@ -141,7 +140,7 @@ class SubGroupTest extends TestCase {
 
 		$this->expectException(GroupException::class);
 		$this->expectExceptionMessage("The group with the display name $displayName already exists.");
-		
+
 		$this->subGroup->create($groupname, $id, $spacename);
 	}
 }

--- a/tests/Unit/Space/SpaceManagerTest.php
+++ b/tests/Unit/Space/SpaceManagerTest.php
@@ -621,11 +621,11 @@ class SpaceManagerTest extends TestCase {
 		string $spacename,
 		string $gid,
 		string $groupname): IGroup {
-		
+
 		$space = $this->createMock(Space::class);
 		$group = $this->createMock(IGroup::class);
 
-    $this->spaceMapper
+		$this->spaceMapper
 			->expects($this->once())
 			->method('find')
 			->with($id)
@@ -725,7 +725,7 @@ class SpaceManagerTest extends TestCase {
 
 		$gid = 'SPACE-G-/-1';
 		$groupfolderId = 42;
-		
+
 		$actual = $this->createSubgroup($id, $groupfolderId, $spacename, $gid, $groupname);
 
 		$this->assertInstanceOf(IGroup::class, $actual, "The createSubGroup function doesn't return a IGroup instance.");
@@ -738,7 +738,7 @@ class SpaceManagerTest extends TestCase {
 
 		$gid = 'SPACE-G-Place {42}-1';
 		$groupfolderId = 42;
-		
+
 		$actual = $this->createSubgroup($id, $groupfolderId, $spacename, $gid, $groupname);
 
 		$this->assertInstanceOf(IGroup::class, $actual, "The createSubGroup function doesn't return a IGroup instance.");
@@ -751,7 +751,7 @@ class SpaceManagerTest extends TestCase {
 
 		$gid = 'SPACE-G-Place \42\-1';
 		$groupfolderId = 42;
-		
+
 		$actual = $this->createSubgroup($id, $groupfolderId, $spacename, $gid, $groupname);
 
 		$this->assertInstanceOf(IGroup::class, $actual, "The createSubGroup function doesn't return a IGroup instance.");
@@ -764,7 +764,7 @@ class SpaceManagerTest extends TestCase {
 
 		$gid = 'SPACE-G-Place (42)-1';
 		$groupfolderId = 42;
-		
+
 		$actual = $this->createSubgroup($id, $groupfolderId, $spacename, $gid, $groupname);
 
 		$this->assertInstanceOf(IGroup::class, $actual, "The createSubGroup function doesn't return a IGroup instance.");
@@ -908,24 +908,24 @@ class SpaceManagerTest extends TestCase {
 		$actual = $this->spaceManager->findGroupsBySpaceId($spaceId);
 
 		$expected = [
-				'SPACE-GE-1' => [
-					'gid' => 'SPACE-GE-1',
-					'displayName' => 'WM-Espace01',
-					'types' => [
-						'Database'
-					],
-					'usersCount' => 0,
-					'slug' => 'SPACE-GE-1'
+			'SPACE-GE-1' => [
+				'gid' => 'SPACE-GE-1',
+				'displayName' => 'WM-Espace01',
+				'types' => [
+					'Database'
 				],
-				'SPACE-U-1' => [
-					'gid' => 'SPACE-U-1',
-					'displayName' => 'U-Espace01',
-					'types' => [
-						'Database'
-					],
-					'usersCount' => 0,
-					'slug' => 'SPACE-U-1'
-				]
+				'usersCount' => 0,
+				'slug' => 'SPACE-GE-1'
+			],
+			'SPACE-U-1' => [
+				'gid' => 'SPACE-U-1',
+				'displayName' => 'U-Espace01',
+				'types' => [
+					'Database'
+				],
+				'usersCount' => 0,
+				'slug' => 'SPACE-U-1'
+			]
 		];
 
 		$this->assertEquals($expected, $actual);
@@ -939,7 +939,7 @@ class SpaceManagerTest extends TestCase {
 		$user1 = $this->createMock(IUser::class);
 		/** @var IUser&MockObject */
 		$user2 = $this->createMock(IUser::class);
-				
+
 		$this->userManager
 			->expects($this->any())
 			->method('get')
@@ -948,7 +948,7 @@ class SpaceManagerTest extends TestCase {
 			)
 			->willReturnOnConsecutiveCalls($user1, $user2, $user1, $user2)
 		;
-		
+
 		$groupUser = $this->createMock(IGroup::class);
 		$groupWorkspaceManagerUser = $this->createMock(IGroup::class);
 
@@ -964,7 +964,7 @@ class SpaceManagerTest extends TestCase {
 			->with($spaceId)
 			->andReturn('SPACE-U-1')
 		;
-		
+
 		/** @var IGroup&MockObject */
 		$userGroup = $this->createMock(IGroup::class);
 
@@ -989,12 +989,12 @@ class SpaceManagerTest extends TestCase {
 	public function testAddUsersInWorkspace(): void {
 		$spaceId = 1;
 		$uids = ['user1', 'user2'];
-		
+
 		/** @var IUser&MockObject */
 		$user1 = $this->createMock(IUser::class);
 		/** @var IUser&MockObject */
 		$user2 = $this->createMock(IUser::class);
-				
+
 		$this->userManager
 			->expects($this->any())
 			->method('get')
@@ -1003,7 +1003,7 @@ class SpaceManagerTest extends TestCase {
 			)
 			->willReturnOnConsecutiveCalls($user1, $user2, $user1, $user2)
 		;
-		
+
 		$groupUser = $this->createMock(IGroup::class);
 		$groupWorkspaceManagerUser = $this->createMock(IGroup::class);
 
@@ -1019,7 +1019,7 @@ class SpaceManagerTest extends TestCase {
 			->with($spaceId)
 			->andReturn('SPACE-U-1')
 		;
-		
+
 		/** @var IGroup&MockObject */
 		$userGroup = $this->createMock(IGroup::class);
 
@@ -1034,17 +1034,17 @@ class SpaceManagerTest extends TestCase {
 			->method('addUser')
 			->with($this->logicalOr($this->equalTo($user1), $this->equalTo($user2)))
 		;
-		
+
 		$this->spaceManager->addUsersInWorkspace($spaceId, $uids);
 	}
-		
+
 	public function testAddUserAsWorkspaceManager(): void {
 		$spaceId = 4;
 		$uid = 'user01';
 
 		/** @var MockObject&IUser */
 		$user = $this->createMock(IUser::class);
-		
+
 		$this->userManager
 			->expects($this->once())
 			->method('get')
@@ -1052,7 +1052,7 @@ class SpaceManagerTest extends TestCase {
 			->willReturn($user)
 		;
 
-		
+
 		$workspaceManagerGroupMock = Mockery::mock(WorkspaceManagerGroup::class);
 		$workspaceManagerGroupMock
 			->shouldReceive('get')
@@ -1138,7 +1138,7 @@ class SpaceManagerTest extends TestCase {
 		$user2 = $this->createMock(IUser::class);
 		/** @var IUser|null */
 		$user42 = null;
-				
+
 		$this->userManager
 			->expects($this->any())
 			->method('get')


### PR DESCRIPTION
- /space/{id} ne renvoie pas 404 sur workspace inexistant
- openapi doc pour PATCH /space/{id}
- api/v1/nimportequoi renvoie OK
- Create a new workspace : pas /spaces mais /space
- Create a new workspace : pas "spacename" mais "name" (comme le champ qu'on obtient en get)
- Create a new workspace : ajout du retour 409 (conflict)
- openapi doc pour addUserAsWorkspaceManager
- openapi doc pour removeUserAsWorkspaceManager
- le DELETE workspace a un problème (m'a effacé le groupfolder mais pas le workspace)
- Params en niveau params{} dans edit
- Edit avec même nom crash
- Create subgroup /groups -> /group
- Create subgroup param "name" et pas "groupname"
- Ajouter openapi.json
- AddUserWM et removeUserWM -> n'existe pas doc 404
- scripts/api-test.js run OCS api scenario