### PR TITLE
Can't add connected group from workspace menu

### DIFF
--- a/src/SpaceDetails.vue
+++ b/src/SpaceDetails.vue
@@ -157,6 +157,9 @@ export default {
 		title() {
 			return this.$route.params.space
 		},
+		space() {
+			return this.$store.state.spaces[this.$route.params.space]
+		},
 	},
 	beforeMount() {
 		const space = this.$store.state.spaces[this.$route.params.space]


### PR DESCRIPTION
- fill "space" computed value

(note: only for 4.0.5, and not 4.1)