### PR TITLE
Remove files from groupfolders on the web server

### DIFF
--- a/lib/Exceptions/MountProviderFunctionException.php
+++ b/lib/Exceptions/MountProviderFunctionException.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * @copyright Copyright (c) 2017 Arawa
+ *
+ * @author 2025 Baptiste Fotia <baptiste.fotia@arawa.fr>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Workspace\Exceptions;
+
+class MountProviderFunctionException extends \Exception {
+	public function __construct(string $message, int $code = 0) {
+		parent::__construct($message, $code);
+	}
+}

--- a/lib/Helper/MountProviderHelper.php
+++ b/lib/Helper/MountProviderHelper.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * @copyright Copyright (c) 2017 Arawa
+ *
+ * @author 2025 Baptiste Fotia <baptiste.fotia@arawa.fr>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Workspace\Helper;
+
+use OCA\GroupFolders\Mount\MountProvider;
+use OCA\Workspace\Exceptions\MountProviderFunctionException;
+use OCP\AutoloadNotAllowedException;
+use OCP\Files\Node;
+use Psr\Container\ContainerExceptionInterface;
+use Psr\Container\ContainerInterface;
+
+class MountProviderHelper {
+	private ?MountProvider $mountProvider = null;
+	private string $dependencyInjectionError = '';
+
+	public function __construct(ContainerInterface $appContainer) {
+		try {
+			$this->mountProvider = $appContainer->get(MountProvider::class);
+		} catch (ContainerExceptionInterface|AutoloadNotAllowedException $e) {
+			// Could not instantiate - probably groupfolders is disabled.
+			$this->dependencyInjectionError = $e->getMessage();
+		}
+	}
+
+	public function getFolder(int $id, bool $create = true): ?Node {
+		try {
+			return $this->mountProvider->getFolder($id, $create);
+		} catch (\Exception $e) {
+			throw new MountProviderFunctionException($e->getMessage(), $e->getCode());
+		}
+	}
+}

--- a/lib/Space/SpaceManager.php
+++ b/lib/Space/SpaceManager.php
@@ -36,6 +36,7 @@ use OCA\Workspace\Group\Admin\AdminUserGroup;
 use OCA\Workspace\Group\SubGroups\SubGroup;
 use OCA\Workspace\Group\User\UserGroup as UserWorkspaceGroup;
 use OCA\Workspace\Helper\GroupfolderHelper;
+use OCA\GroupFolders\Mount\MountProvider;
 use OCA\Workspace\Service\ColorCode;
 use OCA\Workspace\Service\Group\ConnectedGroupsService;
 use OCA\Workspace\Service\Group\GroupFormatter;
@@ -57,6 +58,7 @@ class SpaceManager {
 		private AdminGroup $adminGroup,
 		private AdminUserGroup $adminUserGroup,
 		private AddedGroups $addedGroups,
+		private MountProvider $mountProvider,
 		private SubGroup $subGroup,
 		private UserWorkspaceGroup $userWorkspaceGroup,
 		private SpaceMapper $spaceMapper,
@@ -236,6 +238,8 @@ class SpaceManager {
 		}
 
 		$folderId = $space['groupfolder_id'];
+		$folder = $this->mountProvider->getFolder($folderId);
+		$folder->delete();
 		$this->folderHelper->removeFolder($folderId);
 	}
 

--- a/lib/Space/SpaceManager.php
+++ b/lib/Space/SpaceManager.php
@@ -24,6 +24,7 @@
 
 namespace OCA\Workspace\Space;
 
+use OCA\GroupFolders\Mount\MountProvider;
 use OCA\Workspace\Db\Space;
 use OCA\Workspace\Db\SpaceMapper;
 use OCA\Workspace\Exceptions\BadRequestException;
@@ -36,7 +37,6 @@ use OCA\Workspace\Group\Admin\AdminUserGroup;
 use OCA\Workspace\Group\SubGroups\SubGroup;
 use OCA\Workspace\Group\User\UserGroup as UserWorkspaceGroup;
 use OCA\Workspace\Helper\GroupfolderHelper;
-use OCA\GroupFolders\Mount\MountProvider;
 use OCA\Workspace\Service\ColorCode;
 use OCA\Workspace\Service\Group\ConnectedGroupsService;
 use OCA\Workspace\Service\Group\GroupFormatter;
@@ -71,11 +71,11 @@ class SpaceManager {
 		private ColorCode $colorCode,
 	) {
 	}
-	
+
 	public function create(string $spacename): array {
-		if ($spacename === false ||
-			$spacename === null ||
-			$spacename === ''
+		if ($spacename === false
+			|| $spacename === null
+			|| $spacename === ''
 		) {
 			throw new BadRequestException('Error creating workspace', 'spaceName must be provided');
 		}
@@ -83,7 +83,7 @@ class SpaceManager {
 		if ($this->workspaceCheck->containSpecialChar($spacename)) {
 			throw new BadRequestException('Error creating workspace', 'Your Workspace name must not contain the following characters: ' . implode(' ', str_split(WorkspaceCheckService::CHARACTERS_SPECIAL)));
 		}
-		
+
 		if ($this->workspaceCheck->isExist($spacename)) {
 			throw new WorkspaceNameExistException(
 				title: 'Error - Duplicate space name',

--- a/lib/Space/SpaceManager.php
+++ b/lib/Space/SpaceManager.php
@@ -24,7 +24,6 @@
 
 namespace OCA\Workspace\Space;
 
-use OCA\GroupFolders\Mount\MountProvider;
 use OCA\Workspace\Db\Space;
 use OCA\Workspace\Db\SpaceMapper;
 use OCA\Workspace\Exceptions\BadRequestException;
@@ -37,6 +36,7 @@ use OCA\Workspace\Group\Admin\AdminUserGroup;
 use OCA\Workspace\Group\SubGroups\SubGroup;
 use OCA\Workspace\Group\User\UserGroup as UserWorkspaceGroup;
 use OCA\Workspace\Helper\GroupfolderHelper;
+use OCA\Workspace\Helper\MountProviderHelper;
 use OCA\Workspace\Service\ColorCode;
 use OCA\Workspace\Service\Group\ConnectedGroupsService;
 use OCA\Workspace\Service\Group\GroupFormatter;
@@ -58,7 +58,7 @@ class SpaceManager {
 		private AdminGroup $adminGroup,
 		private AdminUserGroup $adminUserGroup,
 		private AddedGroups $addedGroups,
-		private MountProvider $mountProvider,
+		private MountProviderHelper $mountProviderHelper,
 		private SubGroup $subGroup,
 		private UserWorkspaceGroup $userWorkspaceGroup,
 		private SpaceMapper $spaceMapper,
@@ -238,7 +238,7 @@ class SpaceManager {
 		}
 
 		$folderId = $space['groupfolder_id'];
-		$folder = $this->mountProvider->getFolder($folderId);
+		$folder = $this->mountProviderHelper->getFolder($folderId);
 		$folder->delete();
 		$this->folderHelper->removeFolder($folderId);
 	}

--- a/scripts/database_checker.php
+++ b/scripts/database_checker.php
@@ -35,11 +35,11 @@ require_once __DIR__ . '/../../../lib/base.php';
 use OC\SystemConfig;
 use OCA\GroupFolders\Folder\FolderManager;
 use OCA\Workspace\Db\SpaceMapper;
-use OCP\Files\IRootFolder;
+use OCA\Workspace\Group\Admin\AdminGroup;
 
 // workspace
-use OCA\Workspace\Group\Admin\AdminGroup;
 use OCA\Workspace\Group\User\UserGroup;
+use OCP\Files\IRootFolder;
 use OCP\IDBConnection;
 
 // GroupFolders
@@ -63,8 +63,8 @@ trait InactiveGroupfolders {
 		$folderIds = array_values(array_map(fn ($groupfolder) => $groupfolder['id'], $groupfolders));
 
 		$regex = '/.*[0-9].*/';
-		$folders = array_filter($pathes, fn($path) => preg_match($regex, $path));
-		
+		$folders = array_filter($pathes, fn ($path) => preg_match($regex, $path));
+
 		$idsWithPath = array_map(fn ($id) => "{$groupfolderPath}/{$id}", $folderIds);
 
 		$foldersShadow = array_values(array_diff($folders, $idsWithPath));
@@ -81,7 +81,7 @@ class WorkSpaceChecker {
 	private array $groups;
 
 	use InactiveGroupfolders;
-	
+
 	public function __construct(
 		private IDBConnection $dbConnection,
 		private SpaceMapper $spaceMapper,
@@ -277,8 +277,7 @@ class Run {
 	public function __construct(
 		private FolderManager $folderManager,
 		private IRootFolder $rootFolder,
-	)
-	{
+	) {
 	}
 
 	use InactiveGroupfolders;
@@ -286,11 +285,11 @@ class Run {
 	public function deleteInactiveGroupfolders() {
 		$res = readline("Are you sure want to delete all inactive groupfolders? (yes/Y to confirm)\n");
 		$res = strtolower($res);
-		
+
 		if (!($res === 'yes' || $res === 'y')) {
 			return;
 		}
-		
+
 		$foldersShadow = $this->getInactiveGroupfolders();
 
 		foreach ($foldersShadow as $folderPath) {

--- a/scripts/database_checker.php
+++ b/scripts/database_checker.php
@@ -62,7 +62,7 @@ trait InactiveGroupfolders {
 		$groupfolders = $this->folderManager->getAllFolders();
 		$folderIds = array_values(array_map(fn ($groupfolder) => $groupfolder['id'], $groupfolders));
 
-		$regex = '/.*[0-9].*/';
+		$regex = '/.*[0-9]+/';
 		$folders = array_filter($pathes, fn ($path) => preg_match($regex, $path));
 
 		$idsWithPath = array_map(fn ($id) => "{$groupfolderPath}/{$id}", $folderIds);
@@ -232,7 +232,7 @@ class WorkSpaceChecker {
 		$foldersShadow = implode(PHP_EOL, $foldersShadow);
 
 		echo self::separator();
-		echo 'Checking groupfolders on the filesystem...' . PHP_EOL;
+		echo 'Looking for inactive groupfolders on the filesystem' . PHP_EOL;
 		print($foldersShadow);
 		print(PHP_EOL);
 	}

--- a/tests/Unit/Space/SpaceManagerTest.php
+++ b/tests/Unit/Space/SpaceManagerTest.php
@@ -90,7 +90,7 @@ class SpaceManagerTest extends TestCase {
 	private MockObject&LoggerInterface $logger;
 
 	private MockObject&MountProvider $mountProvider;
-	
+
 	private SpaceManager $spaceManager;
 
 	public function setUp(): void {
@@ -148,8 +148,8 @@ class SpaceManagerTest extends TestCase {
 
 		$this->rootFolder
 			->expects($this->once())
-				->method('getRootFolderStorageId')
-				->willReturn(1)
+			->method('getRootFolderStorageId')
+			->willReturn(1)
 		;
 
 		$this->folderHelper

--- a/tests/Unit/Space/SpaceManagerTest.php
+++ b/tests/Unit/Space/SpaceManagerTest.php
@@ -26,7 +26,6 @@ declare(strict_types=1);
 
 namespace OCA\Workspace\Tests\Unit\Controller;
 
-use OCA\GroupFolders\Mount\MountProvider;
 use OCA\Workspace\Db\SpaceMapper;
 use OCA\Workspace\Exceptions\AbstractNotification;
 use OCA\Workspace\Exceptions\BadRequestException;
@@ -38,6 +37,7 @@ use OCA\Workspace\Group\Admin\AdminUserGroup;
 use OCA\Workspace\Group\SubGroups\SubGroup;
 use OCA\Workspace\Group\User\UserGroup as UserWorkspaceGroup;
 use OCA\Workspace\Helper\GroupfolderHelper;
+use OCA\Workspace\Helper\MountProviderHelper;
 use OCA\Workspace\Service\ColorCode;
 use OCA\Workspace\Service\Group\ConnectedGroupsService;
 use OCA\Workspace\Service\Group\UserGroup;
@@ -89,7 +89,7 @@ class SpaceManagerTest extends TestCase {
 
 	private MockObject&LoggerInterface $logger;
 
-	private MockObject&MountProvider $mountProvider;
+	private MockObject&MountProviderHelper $mountProviderHelper;
 
 	private SpaceManager $spaceManager;
 
@@ -113,7 +113,7 @@ class SpaceManagerTest extends TestCase {
 		$this->userFormatter = $this->createMock(UserFormatter::class);
 		$this->userService = $this->createMock(UserService::class);
 		$this->groupManager = $this->createMock(IGroupManager::class);
-		$this->mountProvider = $this->createMock(MountProvider::class);
+		$this->mountProviderHelper = $this->createMock(MountProviderHelper::class);
 
 
 		$this->spaceManager = new SpaceManager(
@@ -124,7 +124,7 @@ class SpaceManagerTest extends TestCase {
 			$this->adminGroup,
 			$this->adminUserGroup,
 			$this->addedGroups,
-			$this->mountProvider,
+			$this->mountProviderHelper,
 			$this->subGroup,
 			$this->userWorkspaceGroup,
 			$this->spaceMapper,

--- a/tests/Unit/Space/SpaceManagerTest.php
+++ b/tests/Unit/Space/SpaceManagerTest.php
@@ -26,6 +26,7 @@ declare(strict_types=1);
 
 namespace OCA\Workspace\Tests\Unit\Controller;
 
+use OCA\GroupFolders\Mount\MountProvider;
 use OCA\Workspace\Db\SpaceMapper;
 use OCA\Workspace\Exceptions\AbstractNotification;
 use OCA\Workspace\Exceptions\BadRequestException;
@@ -88,6 +89,8 @@ class SpaceManagerTest extends TestCase {
 
 	private MockObject&LoggerInterface $logger;
 
+	private MockObject&MountProvider $mountProvider;
+	
 	private SpaceManager $spaceManager;
 
 	public function setUp(): void {
@@ -110,6 +113,7 @@ class SpaceManagerTest extends TestCase {
 		$this->userFormatter = $this->createMock(UserFormatter::class);
 		$this->userService = $this->createMock(UserService::class);
 		$this->groupManager = $this->createMock(IGroupManager::class);
+		$this->mountProvider = $this->createMock(MountProvider::class);
 
 
 		$this->spaceManager = new SpaceManager(
@@ -120,6 +124,7 @@ class SpaceManagerTest extends TestCase {
 			$this->adminGroup,
 			$this->adminUserGroup,
 			$this->addedGroups,
+			$this->mountProvider,
 			$this->subGroup,
 			$this->userWorkspaceGroup,
 			$this->spaceMapper,
@@ -141,8 +146,8 @@ class SpaceManagerTest extends TestCase {
 			->willReturn(1)
 		;
 
-		$this->rootFolder->
-			expects($this->once())
+		$this->rootFolder
+			->expects($this->once())
 				->method('getRootFolderStorageId')
 				->willReturn(1)
 		;


### PR DESCRIPTION
OP#4199

The code to delete groupfolders after updating the workspace app or running a script :

```php
		/** @var \OCP\Files\Folder $folder */
		$folder = $this->rootFolderTest->get('__groupfolders');
		$groupfolderPath = $folder->getPath();
		$folders = $folder->getDirectoryListing();
		$pathes = array_map(fn ($node) => $node->getPath(), $folders);

		$groupfolders = $this->folderHelper->getAllFolders();
		$folderIds = array_values(array_map(fn ($groupfolder) => $groupfolder['id'], $groupfolders));
		
		$folders = array_filter($pathes, fn ($path) => !str_ends_with($path, 'versions') && !str_ends_with($path, 'trash'));
		
		$idsWithPath = array_map(fn ($id) => "{$groupfolderPath}/{$id}", $folderIds);

		$foldersShadow = array_values(array_diff($folders, $idsWithPath));

		foreach ($foldersShadow as $folderPath) {
			$folder = $this->rootFolderTest->get($folderPath);
			$folder->delete();
		}
```

```php
// lib/Helper/GroupfolderHelper.php

	public function getAllFolders() {
		try {
			return $this->folderManager->getAllFolders();
		} catch (\Exception $e) {
			throw new GroupFolderFunctionException($e->getMessage() . 'Impossible to use the getAllFolders function from FolderManager.');
		}
	}
``` 