### PR TITLE
Close the add user modal  when clicking on the close button

### DIFF
--- a/src/SpaceDetails.vue
+++ b/src/SpaceDetails.vue
@@ -104,7 +104,7 @@
 		<NcDialog v-if="showSelectUsersModal"
 			:name="t('workspace', 'Add users')"
 			size="normal"
-			:open="toggleShowSelectUsersModal">
+			:open.sync="showSelectUsersModal">
 			<AddUsersTabs @close-sidebar="toggleShowSelectUsersModal" />
 		</NcDialog>
 		<SelectConnectedGroups v-if="showSelectConnectedGroups"


### PR DESCRIPTION
# Before

[close-adding-user-before-fix.webm](https://github.com/user-attachments/assets/4514cba4-caf6-400a-9164-f43ad714d9da)

# After
[close-adding-user-after-fix.webm](https://github.com/user-attachments/assets/5cef85cc-42dc-43bb-ab69-801aabd9ceda)

OP#4370
