### PR TITLE
Move the user import information icon to be closer to the tab's title

### DIFF
--- a/src/AddUsersTabs.vue
+++ b/src/AddUsersTabs.vue
@@ -484,7 +484,7 @@ section.app-sidebar__tab--active {
 .information-import {
 	position: absolute;
 	top: 56px;
-	right: 54px;
+	right: 66px;
 	z-index: 9999;
 }
 


### PR DESCRIPTION
|before|after|
|:--:|:--:|
|<img width="638" height="99" alt="image" src="https://github.com/user-attachments/assets/e4e5bd50-6674-47a2-8fb0-b0d04bf799a7" />|<img width="638" height="121" alt="image" src="https://github.com/user-attachments/assets/e16930e8-b66e-4275-bb16-1505a1847c1a" />|

OP#4374