### PR TITLE
Disable the avatar menu on the spaces page

### DIFF
--- a/src/SpaceTable.vue
+++ b/src/SpaceTable.vue
@@ -61,6 +61,7 @@
 								:key="user.uid"
 								:style="{ marginRight: 2 + 'px' }"
 								:display-name="user.name"
+								:disable-menu="true"
 								:show-user-status="false"
 								:user="user.uid" />
 						</VueLazyComponent>


### PR DESCRIPTION
|before|after|
|:--:|:--:|
|<img width="239" height="125" alt="image" src="https://github.com/user-attachments/assets/79d3d449-0905-44ca-92bd-d9473d77e671" />|<img width="239" height="158" alt="image" src="https://github.com/user-attachments/assets/6c9a830a-28fe-4023-8499-1653ba684082" />|

~~OP#4374~~

OP#4376