### PR TITLE
Align the "Workspace Managers" column name to the right

### DIFF
--- a/src/SpaceTable.vue
+++ b/src/SpaceTable.vue
@@ -33,7 +33,7 @@
 					<th class="workspace-th">
 						{{ t('workspace', 'Quota') }}
 					</th>
-					<th class="workspace-th">
+					<th class="workspace-th workspace-managers-th">
 						{{ t('workspace', 'Space administrators') }}
 					</th>
 				</tr>
@@ -158,4 +158,8 @@ td, td div {
 	cursor: pointer;
 }
 
+.workspace-managers-th {
+	text-align: right;
+	padding-right: 80px;
+}
 </style>


### PR DESCRIPTION
|before|after|
|:--:|:--:|
|<img width="1555" height="333" alt="image" src="https://github.com/user-attachments/assets/05e19a6e-c0fd-419c-af7d-b432e1a5760a" />|<img width="1555" height="333" alt="image" src="https://github.com/user-attachments/assets/83f083ef-ec40-4410-be54-9acb4e56e585" />|

OP#4380