### PR TITLE
Resize the user selection modal for screen widths less than 900px

### DIFF
--- a/src/AddUsersTabs.vue
+++ b/src/AddUsersTabs.vue
@@ -382,13 +382,29 @@ section.app-sidebar__tab--active {
 }
 
 .select-users-wrapper :deep(header.app-sidebar-header) {
-    display: none !important;
+	display: none !important;
 }
 
 // Change the height of the modal container
 // to make space for the NcNoteCard
 .modal-container {
 	max-height: 900px !important;
+}
+
+@media only screen and (max-height: 700px) {
+	.select-users-list-empty {
+		line-height: 150px !important;
+	}
+
+	.select-users-list {
+		height: 160px !important;
+		margin: 0 !important;
+	}
+
+	.note-card {
+		font-size: 12px !important;
+	}
+
 }
 
 // Fix : tabs implies a min-height of 256 that overlaps the user list

--- a/src/SpaceDetails.vue
+++ b/src/SpaceDetails.vue
@@ -279,6 +279,12 @@ export default {
 	display: flex;
 }
 
+@media only screen and (max-width: 900px) {
+	.dialog-addusers-tabs .modal-wrapper .modal-container {
+		max-height: 500px !important;
+	}
+}
+
 .color-picker {
 	margin: 0px;
 }


### PR DESCRIPTION
OP#4378

<!---
# Before

[zoom-on-adding-user-modal-before-fix.webm](https://github.com/user-attachments/assets/25fdce16-5352-4a4d-bc7c-1f24fcfb6660)

# After
-->
