### PR TITLE
Fix the add users modal for subgroups

### DIFF
--- a/src/GroupDetails.vue
+++ b/src/GroupDetails.vue
@@ -74,7 +74,7 @@
 		<NcDialog v-if="showSelectUsersModal"
 			:name="t('workspace', 'Add users')"
 			size="normal"
-			:open="toggleShowSelectUsersModal">
+			:open.sync="showSelectUsersModal">
 			<AddUsersTabs @close-sidebar="toggleShowSelectUsersModal" />
 		</NcDialog>
 		<AlertRemoveGroup v-if="showRemoveConnectedGroupModal"


### PR DESCRIPTION
# Before

[close-adding-users-for-subgroups-before-fix.webm](https://github.com/user-attachments/assets/ff2a36a3-8a26-4b0f-a716-4af8b235b295)

# After

[close-adding-users-for-subgroups-after-fix.webm](https://github.com/user-attachments/assets/1f478f1b-1985-4587-82dc-32c7c5381d71)


OP#4370