### PR TITLE
[CHANGED] Set added group icon to 16px in action menu

### DIFF
--- a/src/SpaceDetails.vue
+++ b/src/SpaceDetails.vue
@@ -64,8 +64,10 @@
 						@click="toggleShowConnectedGroups">
 						<template #icon>
 							<NcIconSvgWrapper v-if="isDarkTheme"
+								:size="16"
 								:svg="AddedGroupWhite" />
 							<NcIconSvgWrapper v-else
+								:size="16"
 								:svg="AddedGroupBlack" />
 						</template>
 						{{ t('workspace', 'Add a group') }}


### PR DESCRIPTION
|before|after|
|:---:|:---:|
|<img width="255" height="175" alt="image" src="https://github.com/user-attachments/assets/9184915a-c904-4530-bb4f-d9a07b15fa54" />|<img width="255" height="175" alt="image" src="https://github.com/user-attachments/assets/1b4f09b7-d4e4-41e5-8edf-760805f5db14" />|

OP#4373