### PR TITLE
[FIXED] Backport: Move the workspace managers column content to the left

### DIFF
--- a/src/SpaceTable.vue
+++ b/src/SpaceTable.vue
@@ -153,7 +153,6 @@ export default {
 <style>
 .admin-avatars {
 	display: flex;
-	flex-flow: row-reverse;
 }
 
 .container-avatars {
@@ -195,7 +194,6 @@ td, td div {
 }
 
 .workspace-managers-th {
-	text-align: right;
-	padding-right: 80px;
+	text-align: left;
 }
 </style>


### PR DESCRIPTION
OP#4380

from #1499 