### PR TITLE
[FIXED] Show options when quota selected

### DIFF
--- a/src/components/Modals/EditWorkspace.vue
+++ b/src/components/Modals/EditWorkspace.vue
@@ -30,7 +30,7 @@
 				<NcSelect :value.sync="getQuota"
 					aria-label-combobox="set quota"
 					class="quota-input"
-					:clear-search-on-select="false"
+					:clear-search-on-select="true"
 					:taggable="true"
 					:disabled="$root.$data.isUserGeneralAdmin === 'false'"
 					:placeholder="t('workspace', 'Set quota')"


### PR DESCRIPTION
## Before

[before-show-options-when-quota-selected-.webm](https://github.com/user-attachments/assets/22ffec82-efea-400c-85f2-f8dad3e6f15d)

## After

[after-show-options-when-quota-selected-.webm](https://github.com/user-attachments/assets/acc8bf1c-f579-4a63-a4de-ed87dacab364)

**source**: https://vue-select.org/api/props.html#clearsearchonselect