### PR TITLE
[FIX] Remove users from Workspace Manager after refreshing workspace view

### DIFF
--- a/src/SpaceDetails.vue
+++ b/src/SpaceDetails.vue
@@ -202,6 +202,10 @@ export default {
 		} else {
 			this.$store.dispatch('setNoUsers', { activated: false })
 		}
+
+		if (this.space.managers === null) {
+			this.$store.dispatch('loadAdmins', { space: this.space })
+		}
 	},
 	beforeUpdate() {
 		this.space = this.$store.getters.getSpaceByNameOrId(this.$route.params.space)

--- a/src/SpaceTable.vue
+++ b/src/SpaceTable.vue
@@ -152,7 +152,7 @@ export default {
 				if (space.managers !== null || space.users.length > 0) {
 					return
 				}
-				this.$store.dispatch('loadAdmins', space)
+				this.$store.dispatch('loadAdmins', { space })
 			}
 		},
 		getFirstTenWorkspaceManagerUsers(spacename) {

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -538,7 +538,7 @@ export default {
 	setNoUsers(context, { activated }) {
 		context.commit('SET_NO_USERS', ({ activated }))
 	},
-	async loadAdmins(context, space) {
+	async loadAdmins(context, { space }) {
 		const url = generateUrl(`/apps/workspace/space/${space.id}/admin-users`)
 		axios.get(url)
 			.then(response => {


### PR DESCRIPTION
Remove users from the Workspace Manager group (SPACE-GE-<SPACE_ID>) after refreshing a workspace view to keep the Vuex store consistent. Updated components and store actions accordingly.

## Before

[before-remove-wm-from-workspace-page.webm](https://github.com/user-attachments/assets/9cd58f8b-c168-4817-be2f-640d130ebcaa)

## After

[after-remove-wm-from-workspace-page.webm](https://github.com/user-attachments/assets/ec0b472e-0738-4cf7-99cf-21cf8a23e61a)