### PR TITLE
[FIX] Replace spaceId with spacename in added group removal message

### DIFF
--- a/src/GroupDetails.vue
+++ b/src/GroupDetails.vue
@@ -78,7 +78,7 @@
 			<AddUsersTabs @close-sidebar="toggleShowSelectUsersModal" />
 		</NcDialog>
 		<AlertRemoveGroup v-if="showRemoveConnectedGroupModal"
-			:message="t('workspace', 'Warning, after removal of group <b>{groupname}</b>, its users will lose access to the <b>{spacename}</b> workspace, with the exception of:<br><br>- Workspace Managers (<b>WM-{spacename}</b>)<br>- users who are members of <b>Workspace groups</b> (prefixed <b>G-</b>)<br>- users who are members of another Added Group<br>- users manually added from the Workspace <b>{spacename}</b>', { groupname: decodeURIComponent(decodeURIComponent($route.params.slug)), spacename: $route.params.space }, null, { escape: false })"
+			:message="t('workspace', 'Warning, after removal of group <b>{groupname}</b>, its users will lose access to the <b>{spacename}</b> workspace, with the exception of:<br><br>- Workspace Managers (<b>WM-{spacename}</b>)<br>- users who are members of <b>Workspace groups</b> (prefixed <b>G-</b>)<br>- users who are members of another Added Group<br>- users manually added from the Workspace <b>{spacename}</b>', { groupname: decodeURIComponent(decodeURIComponent($route.params.slug)), spacename: getSpaceName }, null, { escape: false })"
 			@cancel="closeConnectedGroupModal"
 			@remove-group="removeConnectedGroup" />
 		<AlertRemoveGroup v-if="showRemoveGroupModal"


### PR DESCRIPTION
|before|after|
|:---:|:---:|
|<img width="759" height="402" alt="image" src="https://github.com/user-attachments/assets/a4ec3e63-0936-4c96-b90b-b6cae31f1e61" />|<img width="759" height="402" alt="image" src="https://github.com/user-attachments/assets/ec474de7-f76b-4b16-bb61-d29c29e2fb4f" />|

Replace spaceId with spacename in the added-group removal modal so the workspace name is shown instead of its ID.