### PR TITLE
[FIX] Remove users from Workspace Manager after refreshing group view

### DIFF
--- a/src/GroupDetails.vue
+++ b/src/GroupDetails.vue
@@ -149,6 +149,10 @@ export default {
 	mounted() {
 		const space = this.$store.getters.getSpaceByNameOrId(this.$route.params.space)
 		this.$store.dispatch('loadUsers', { space })
+
+		if (space.managers === null) {
+			this.$store.dispatch('loadAdmins', { space })
+		}
 	},
 	methods: {
 		deleteGroup() {


### PR DESCRIPTION
Remove users from the Workspace Manager group (SPACE-GE-<SPACE_ID>) after refreshing a group view to keep the Vuex store consistent.

### before

[before-remove-wm-from-subgroup-page.webm](https://github.com/user-attachments/assets/8486520e-193d-400d-a3ca-1843824823fd)

### after

[after-remove-wm-from-subgroup-page.webm](https://github.com/user-attachments/assets/b7ebae74-f48d-45dd-8d82-5e2e60d4d671)
