### PR TITLE
[FIXED][BACKPORT] Remove users from Workspace Manager after refreshing group view

### DIFF
--- a/src/GroupDetails.vue
+++ b/src/GroupDetails.vue
@@ -149,6 +149,10 @@ export default {
 	mounted() {
 		const space = this.$store.getters.getSpaceByNameOrId(this.$route.params.space)
 		this.$store.dispatch('loadUsers', { space })
+
+		if (space.managers === null) {
+			this.$store.dispatch('loadAdmins', { space })
+		}
 	},
 	methods: {
 		deleteGroup() {


### PR DESCRIPTION
Remove users from the Workspace Manager group (SPACE-GE-<SPACE_ID>) after refreshing a group view to keep the Vuex store consistent.

Backport from #1580 